### PR TITLE
spec: doc version negotiation w/ Identity RPCs

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -228,45 +228,6 @@ There are three sets of RPCs:
 * **Node Service**: The Node Plugin MUST implement this sets of RPCs.
 
 ```protobuf
-// Identity service RPCs allow a CO to negotiate an API protocol
-// version that MAY be used for subsequent RPCs across all CSI services
-// with respect to a particular CSI plugin. The general flow of the
-// success case is as follows (protos illustrated in YAML for brevity):
-//
-// 1. CO queries supported versions via Identity RPC. The CO is expected
-//    to gracefully handle, in the manner of its own choosing, the case
-//    wherein the returned `supported_versions` from the plugin are not
-//    supported by the CO.
-//
-//    CO --(GetSupportedVersions)--> Plugin
-//
-//    request: {}
-//    response:
-//      result:
-//        supported_versions:
-//          - major: 0
-//            minor: 1
-//            patch: 0
-//
-// 2. CO queries metadata via Identity RPC, using a supported API
-//    protocol version (as per the reply from the prior step): the
-//    requested `version` MUST match an entry from the aforementioned
-//    `supported_versions` array.
-//
-//    CO --(GetPluginInfo)--> Plugin
-//
-//    request:
-//      version:
-//        major: 0
-//        minor: 1
-//        patch: 0
-//    response:
-//      result:
-//        name: org.foo.whizbang/super-plugin
-//        vendor_version: blue-green
-//        manifest:
-//          baz: qaz
-//
 service Identity {
   rpc GetSupportedVersions (GetSupportedVersionsRequest)
     returns (GetSupportedVersionsResponse) {}
@@ -325,6 +286,47 @@ The plugin should handle this as gracefully as possible.
 The error code `OPERATION_PENDING_FOR_VOLUME` may be returned by the plugin in this case (see general error code section for details).
 
 ### Identity Service RPC
+
+Identity service RPCs allow a CO to negotiate an API protocol
+version that MAY be used for subsequent RPCs across all CSI services
+with respect to a particular CSI plugin. The general flow of the
+success case is as follows (protos illustrated in YAML for brevity):
+
+1. CO queries supported versions via Identity RPC. The CO is expected
+   to gracefully handle, in the manner of its own choosing, the case
+   wherein the returned `supported_versions` from the plugin are not
+   supported by the CO.
+
+```
+   # CO --(GetSupportedVersions)--> Plugin
+   request: {}
+   response:
+     result:
+       supported_versions:
+         - major: 0
+           minor: 1
+           patch: 0
+```
+
+2. CO queries metadata via Identity RPC, using a supported API
+   protocol version (as per the reply from the prior step): the
+   requested `version` MUST match an entry from the aforementioned
+   `supported_versions` array.
+
+```
+   # CO --(GetPluginInfo)--> Plugin
+   request:
+     version:
+       major: 0
+       minor: 1
+       patch: 0
+   response:
+     result:
+       name: org.foo.whizbang/super-plugin
+       vendor_version: blue-green
+       manifest:
+         baz: qaz
+```
 
 #### `GetSupportedVersions`
 

--- a/spec.md
+++ b/spec.md
@@ -287,15 +287,10 @@ The error code `OPERATION_PENDING_FOR_VOLUME` may be returned by the plugin in t
 
 ### Identity Service RPC
 
-Identity service RPCs allow a CO to negotiate an API protocol
-version that MAY be used for subsequent RPCs across all CSI services
-with respect to a particular CSI plugin. The general flow of the
-success case is as follows (protos illustrated in YAML for brevity):
+Identity service RPCs allow a CO to negotiate an API protocol version that MAY be used for subsequent RPCs across all CSI services with respect to a particular CSI plugin.
+The general flow of the success case is as follows (protos illustrated in YAML for brevity):
 
-1. CO queries supported versions via Identity RPC. The CO is expected
-   to gracefully handle, in the manner of its own choosing, the case
-   wherein the returned `supported_versions` from the plugin are not
-   supported by the CO.
+1. CO queries supported versions via Identity RPC. The CO is expected to gracefully handle, in the manner of its own choosing, the case wherein the returned `supported_versions` from the plugin are not supported by the CO.
 
 ```
    # CO --(GetSupportedVersions)--> Plugin
@@ -308,10 +303,7 @@ success case is as follows (protos illustrated in YAML for brevity):
            patch: 0
 ```
 
-2. CO queries metadata via Identity RPC, using a supported API
-   protocol version (as per the reply from the prior step): the
-   requested `version` MUST match an entry from the aforementioned
-   `supported_versions` array.
+2. CO queries metadata via Identity RPC, using a supported API protocol version (as per the reply from the prior step): the requested `version` MUST match an entry from the aforementioned `supported_versions` array.
 
 ```
    # CO --(GetPluginInfo)--> Plugin

--- a/spec.md
+++ b/spec.md
@@ -228,6 +228,45 @@ There are three sets of RPCs:
 * **Node Service**: The Node Plugin MUST implement this sets of RPCs.
 
 ```protobuf
+// Identity service RPCs allow a CO to negotiate an API protocol
+// version that MAY be used for subsequent RPCs across all CSI services
+// with respect to a particular CSI plugin. The general flow of the
+// success case is as follows (protos illustrated in YAML for brevity):
+//
+// 1. CO queries supported versions via Identity RPC. The CO is expected
+//    to gracefully handle, in the manner of its own choosing, the case
+//    wherein the returned `supported_versions` from the plugin are not
+//    supported by the CO.
+//
+//    CO --(GetSupportedVersions)--> Plugin
+//
+//    request: {}
+//    response:
+//      result:
+//        supported_versions:
+//          - major: 0
+//            minor: 1
+//            patch: 0
+//
+// 2. CO queries metadata via Identity RPC, using a supported API
+//    protocol version (as per the reply from the prior step): the
+//    requested `version` MUST match an entry from the aforementioned
+//    `supported_versions` array.
+//
+//    CO --(GetPluginInfo)--> Plugin
+//
+//    request:
+//      version:
+//        major: 0
+//        minor: 1
+//        patch: 0
+//    response:
+//      result:
+//        name: org.foo.whizbang/super-plugin
+//        vendor_version: blue-green
+//        manifest:
+//          baz: qaz
+//
 service Identity {
   rpc GetSupportedVersions (GetSupportedVersionsRequest)
     returns (GetSupportedVersionsResponse) {}


### PR DESCRIPTION
Documentation for the Identity gRPC service that illustrates the expected flow of events in the case of a successful API protocol version negotiation between a CO and a plugin implementation.

Also illustrates a possible convention for plugin names as per #3.

xref #65