### PR TITLE
Remove Lang Binding Builds from Root Makefile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,8 @@ This also applies to the code snippets in the markdown files.
 
 ## Git commit
 
-Prior to committing code please run `make` in order to update the protobuf file and any language bindings.
+Prior to committing code please run `make` in order to update the generated protobuf.
+Please also execute `make -C lib/cxx` and `make -C lib/go` to update the Cxx and Go language bindings. The latter will fail if this repository is cloned outside of a [valid `GOPATH`](https://golang.org/doc/code.html#GOPATH).
 
 ### Commit Style
 

--- a/Makefile
+++ b/Makefile
@@ -30,15 +30,16 @@ endif
 
 build: $(CSI_PROTO)
 
-# If this is not running on Travis-CI then for sake of convenience
-# go ahead and update the language bindings as well.
-ifneq (true,$(TRAVIS))
-build:
-	$(MAKE) -C lib/go
-	$(MAKE) -C lib/cxx
-endif
+# the LANGS variable defines the languages for which bindings
+# are generated and used to validate the specification
+LANGS := $(notdir $(wildcard lib/*))
+$(addprefix build-,$(LANGS)):
+	$(MAKE) -C lib/$(@:build-%=%)
+$(addprefix clean-,$(LANGS)):
+	$(MAKE) -C lib/$(@:clean-%=%) clean
+.PHONY: $(foreach l,$(LANGS),build-$l clean-$l)
 
-clean:
+clean: $(addprefix clean-,$(LANGS))
 
 clobber: clean
 	rm -f $(CSI_PROTO) $(CSI_PROTO).tmp


### PR DESCRIPTION
This patch removes part of the root Makefile that would call the language-binding builds when running `make` locally from the root of the project. If the `lib/go` build was executed outside of the `GOPATH` errors would occur. Since the repository is not Go-specific, running a Go-specific build by default should not be assumed.