### PR TITLE
Dep Support

### DIFF
--- a/lib/go/csi.go
+++ b/lib/go/csi.go
@@ -1,0 +1,5 @@
+// Package csi is the Container Storage Interface (CSI) specification
+// repository. This package contains no functional code, and this file
+// exists only to make it possible to import this repository with a Go
+// dependency manager such as Dep (https://github.com/golang/dep).
+package csi


### PR DESCRIPTION
This patch fixes issue #91 by adding support for the official Go dependency tool, Dep. The solution is a nearly-empty Go source file at `lib/go/csi.go` that defines a package with no functional code. However, this package will enable the ability to nil-import `github.com/container-storage-interface/spec/lib/go` so that the Dep tool discovers a valid Go package (a directory with one or more Go sources in it).

For information on why the resolution is not to simply import `github.com/container-storage-interface/spec/lib/go/csi` please see issue #91.