### PR TITLE
Make node_id required in GetNodeIDResponse

### DIFF
--- a/csi.proto
+++ b/csi.proto
@@ -284,10 +284,8 @@ message ControllerPublishVolumeRequest {
   // This field is REQUIRED.
   string volume_id = 2;
 
-  // The ID of the node. This field is OPTIONAL. The CO SHALL set (or
-  // clear) this field to match the node ID returned by `GetNodeID`.
-  // `GetNodeID` is allowed to omit node ID from a successful response;
-  // in such cases the CO SHALL NOT specify this field.
+  // The ID of the node. This field is REQUIRED. The CO SHALL set this
+  // field to match the node ID returned by `GetNodeID`.
   string node_id = 3;
 
   // The capability of the volume the CO expects the volume to have.
@@ -332,15 +330,11 @@ message ControllerUnpublishVolumeRequest {
   // The ID of the volume. This field is REQUIRED.
   string volume_id = 2;
 
-  // The ID of the node. This field is OPTIONAL. The CO SHALL set (or
-  // clear) this field to match the node ID returned by `GetNodeID`.
-  // `GetNodeID` is allowed to omit node ID from a successful response;
-  // in such cases the CO SHALL NOT specify this field.
-  //
-  // If `GetNodeID` does not omit node ID from a successful response,
-  // the CO MAY omit this field as well, indicating that it does not
-  // know which node the volume was previously used. The Plugin SHOULD
-  // return an Error if this is not supported.
+  // The ID of the node. This field is OPTIONAL. The CO SHOULD set this
+  // field to match the node ID returned by `GetNodeID` or leave it
+  // unset. If the value is set, the SP MUST unpublish the volume from
+  // the specified node. If the value is unset, the SP MUST unpublish
+  // the volume from all nodes it is published to.
   string node_id = 3;
 
   // End user credentials used to authenticate/authorize controller
@@ -579,10 +573,9 @@ message GetNodeIDRequest {
 }
 
 message GetNodeIDResponse {
-  // The ID of the node which SHALL be used by CO in
-  // `ControllerPublishVolume`. This is an OPTIONAL field. If unset,
-  // the CO SHALL leave the `node_id` field unset in
-  // `ControllerPublishVolume`.
+  // The ID of the node as understood by the SP which SHALL be used by
+  // CO in subsequent `ControllerPublishVolume`.
+  // This is a REQUIRED field.
   string node_id = 1;
 }
 ////////

--- a/lib/go/csi/csi.pb.go
+++ b/lib/go/csi/csi.pb.go
@@ -732,10 +732,8 @@ type ControllerPublishVolumeRequest struct {
 	// The ID of the volume to be used on a node.
 	// This field is REQUIRED.
 	VolumeId string `protobuf:"bytes,2,opt,name=volume_id,json=volumeId" json:"volume_id,omitempty"`
-	// The ID of the node. This field is OPTIONAL. The CO SHALL set (or
-	// clear) this field to match the node ID returned by `GetNodeID`.
-	// `GetNodeID` is allowed to omit node ID from a successful response;
-	// in such cases the CO SHALL NOT specify this field.
+	// The ID of the node. This field is REQUIRED. The CO SHALL set this
+	// field to match the node ID returned by `GetNodeID`.
 	NodeId string `protobuf:"bytes,3,opt,name=node_id,json=nodeId" json:"node_id,omitempty"`
 	// The capability of the volume the CO expects the volume to have.
 	// This is a REQUIRED field.
@@ -843,15 +841,11 @@ type ControllerUnpublishVolumeRequest struct {
 	Version *Version `protobuf:"bytes,1,opt,name=version" json:"version,omitempty"`
 	// The ID of the volume. This field is REQUIRED.
 	VolumeId string `protobuf:"bytes,2,opt,name=volume_id,json=volumeId" json:"volume_id,omitempty"`
-	// The ID of the node. This field is OPTIONAL. The CO SHALL set (or
-	// clear) this field to match the node ID returned by `GetNodeID`.
-	// `GetNodeID` is allowed to omit node ID from a successful response;
-	// in such cases the CO SHALL NOT specify this field.
-	//
-	// If `GetNodeID` does not omit node ID from a successful response,
-	// the CO MAY omit this field as well, indicating that it does not
-	// know which node the volume was previously used. The Plugin SHOULD
-	// return an Error if this is not supported.
+	// The ID of the node. This field is OPTIONAL. The CO SHOULD set this
+	// field to match the node ID returned by `GetNodeID` or leave it
+	// unset. If the value is set, the SP MUST unpublish the volume from
+	// the specified node. If the value is unset, the SP MUST unpublish
+	// the volume from all nodes it is published to.
 	NodeId string `protobuf:"bytes,3,opt,name=node_id,json=nodeId" json:"node_id,omitempty"`
 	// End user credentials used to authenticate/authorize controller
 	// unpublish request.
@@ -1525,10 +1519,9 @@ func (m *GetNodeIDRequest) GetVersion() *Version {
 }
 
 type GetNodeIDResponse struct {
-	// The ID of the node which SHALL be used by CO in
-	// `ControllerPublishVolume`. This is an OPTIONAL field. If unset,
-	// the CO SHALL leave the `node_id` field unset in
-	// `ControllerPublishVolume`.
+	// The ID of the node as understood by the SP which SHALL be used by
+	// CO in subsequent `ControllerPublishVolume`.
+	// This is a REQUIRED field.
 	NodeId string `protobuf:"bytes,1,opt,name=node_id,json=nodeId" json:"node_id,omitempty"`
 }
 

--- a/spec.md
+++ b/spec.md
@@ -666,10 +666,8 @@ message ControllerPublishVolumeRequest {
   // This field is REQUIRED.
   string volume_id = 2;
 
-  // The ID of the node. This field is OPTIONAL. The CO SHALL set (or
-  // clear) this field to match the node ID returned by `GetNodeID`.
-  // `GetNodeID` is allowed to omit node ID from a successful response;
-  // in such cases the CO SHALL NOT specify this field.
+  // The ID of the node. This field is REQUIRED. The CO SHALL set this
+  // field to match the node ID returned by `GetNodeID`.
   string node_id = 3;
 
   // The capability of the volume the CO expects the volume to have.
@@ -743,15 +741,11 @@ message ControllerUnpublishVolumeRequest {
   // The ID of the volume. This field is REQUIRED.
   string volume_id = 2;
 
-  // The ID of the node. This field is OPTIONAL. The CO SHALL set (or
-  // clear) this field to match the node ID returned by `GetNodeID`.
-  // `GetNodeID` is allowed to omit node ID from a successful response;
-  // in such cases the CO SHALL NOT specify this field.
-  //
-  // If `GetNodeID` does not omit node ID from a successful response,
-  // the CO MAY omit this field as well, indicating that it does not
-  // know which node the volume was previously used. The Plugin SHOULD
-  // return an Error if this is not supported.
+  // The ID of the node. This field is OPTIONAL. The CO SHOULD set this
+  // field to match the node ID returned by `GetNodeID` or leave it
+  // unset. If the value is set, the SP MUST unpublish the volume from
+  // the specified node. If the value is unset, the SP MUST unpublish
+  // the volume from all nodes it is published to.
   string node_id = 3;
 
   // End user credentials used to authenticate/authorize controller
@@ -1123,7 +1117,7 @@ Condition | gRPC Code | Description | Recovery Behavior
 
 #### `GetNodeID`
 
-A Node Plugin MUST implement this RPC call.
+A Node Plugin MUST implement this RPC call if the plugin has `PUBLISH_UNPUBLISH_VOLUME` controller capability.
 The Plugin SHALL assume that this RPC will be executed on the node where the volume will be used.
 The CO SHOULD call this RPC for the node at which it wants to place the workload.
 The result of this call will be used by CO in `ControllerPublishVolume`.
@@ -1135,10 +1129,9 @@ message GetNodeIDRequest {
 }
 
 message GetNodeIDResponse {
-  // The ID of the node which SHALL be used by CO in
-  // `ControllerPublishVolume`. This is an OPTIONAL field. If unset,
-  // the CO SHALL leave the `node_id` field unset in
-  // `ControllerPublishVolume`.
+  // The ID of the node as understood by the SP which SHALL be used by
+  // CO in subsequent `ControllerPublishVolume`.
+  // This is a REQUIRED field.
   string node_id = 1;
 }
 ```


### PR DESCRIPTION
* Make `node_id` a required field in the `GetNodeIDResponse` if the plugin has `PUBLISH_UNPUBLISH_VOLUME` controller capability.
* Make `node_id` a required field in the `ControllerPublishVolume` and `ControllerUnpublishVolume` calls.
* Require CO to pass it's `node_id` in `GetNodeIdReqeust` so that SP's that don't have their own custom internal naming scheme do not have to implement complicated logic to figure out the node name. 

Fixes https://github.com/container-storage-interface/spec/issues/121