### PR TITLE
spec: Clarify Plugin Name Rules

### DIFF
--- a/csi.proto
+++ b/csi.proto
@@ -82,10 +82,10 @@ message GetPluginInfoRequest {
 }
 
 message GetPluginInfoResponse {
-  // Specify the name in Reverse domain name notation format,
-  // (https://en.wikipedia.org/wiki/Reverse_domain_name_notation)
-  // which includes the plugin's host company name and the plugin name,
-  // to minimize the possibility of collisions. The field MUST be 63
+  // The name MUST follow reverse domain name notation format
+  // (https://en.wikipedia.org/wiki/Reverse_domain_name_notation).
+  // It SHOULD include the plugin's host company name and the plugin
+  // name, to minimize the possibility of collisions. It MUST be 63
   // characters or less, beginning and ending with an alphanumeric
   // character ([a-z0-9A-Z]) with dashes (-), underscores (_),
   // dots (.), and alphanumerics between. This field is REQUIRED.

--- a/csi.proto
+++ b/csi.proto
@@ -82,7 +82,13 @@ message GetPluginInfoRequest {
 }
 
 message GetPluginInfoResponse {
-  // This field is REQUIRED.
+  // Specify the name in Reverse domain name notation format,
+  // (https://en.wikipedia.org/wiki/Reverse_domain_name_notation)
+  // which includes the plugin's host company name and the plugin name,
+  // to minimize the possibility of collisions. The field MUST be 63
+  // characters or less, beginning and ending with an alphanumeric
+  // character ([a-z0-9A-Z]) with dashes (-), underscores (_),
+  // dots (.), and alphanumerics between. This field is REQUIRED.
   string name = 1;
 
   // This field is REQUIRED. Value of this field is opaque to the CO.

--- a/lib/go/csi/csi.pb.go
+++ b/lib/go/csi/csi.pb.go
@@ -245,10 +245,10 @@ func (m *GetPluginInfoRequest) GetVersion() *Version {
 }
 
 type GetPluginInfoResponse struct {
-	// Specify the name in Reverse domain name notation format,
-	// (https://en.wikipedia.org/wiki/Reverse_domain_name_notation)
-	// which includes the plugin's host company name and the plugin name,
-	// to minimize the possibility of collisions. The field MUST be 63
+	// The name MUST follow reverse domain name notation format
+	// (https://en.wikipedia.org/wiki/Reverse_domain_name_notation).
+	// It SHOULD include the plugin's host company name and the plugin
+	// name, to minimize the possibility of collisions. It MUST be 63
 	// characters or less, beginning and ending with an alphanumeric
 	// character ([a-z0-9A-Z]) with dashes (-), underscores (_),
 	// dots (.), and alphanumerics between. This field is REQUIRED.

--- a/lib/go/csi/csi.pb.go
+++ b/lib/go/csi/csi.pb.go
@@ -245,7 +245,13 @@ func (m *GetPluginInfoRequest) GetVersion() *Version {
 }
 
 type GetPluginInfoResponse struct {
-	// This field is REQUIRED.
+	// Specify the name in Reverse domain name notation format,
+	// (https://en.wikipedia.org/wiki/Reverse_domain_name_notation)
+	// which includes the plugin's host company name and the plugin name,
+	// to minimize the possibility of collisions. The field MUST be 63
+	// characters or less, beginning and ending with an alphanumeric
+	// character ([a-z0-9A-Z]) with dashes (-), underscores (_),
+	// dots (.), and alphanumerics between. This field is REQUIRED.
 	Name string `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
 	// This field is REQUIRED. Value of this field is opaque to the CO.
 	VendorVersion string `protobuf:"bytes,2,opt,name=vendor_version,json=vendorVersion" json:"vendor_version,omitempty"`

--- a/spec.md
+++ b/spec.md
@@ -400,10 +400,10 @@ message GetPluginInfoRequest {
 }
 
 message GetPluginInfoResponse {
-  // Specify the name in Reverse domain name notation format,
-  // (https://en.wikipedia.org/wiki/Reverse_domain_name_notation)
-  // which includes the plugin's host company name and the plugin name,
-  // to minimize the possibility of collisions. The field MUST be 63
+  // The name MUST follow reverse domain name notation format
+  // (https://en.wikipedia.org/wiki/Reverse_domain_name_notation).
+  // It SHOULD include the plugin's host company name and the plugin
+  // name, to minimize the possibility of collisions. It MUST be 63
   // characters or less, beginning and ending with an alphanumeric
   // character ([a-z0-9A-Z]) with dashes (-), underscores (_),
   // dots (.), and alphanumerics between. This field is REQUIRED.

--- a/spec.md
+++ b/spec.md
@@ -352,7 +352,7 @@ The general flow of the success case is as follows (protos illustrated in YAML f
        minor: 1
        patch: 0
    response:
-      name: org.foo.whizbang/super-plugin
+      name: org.foo.whizbang.super-plugin
       vendor_version: blue-green
       manifest:
         baz: qaz
@@ -400,7 +400,13 @@ message GetPluginInfoRequest {
 }
 
 message GetPluginInfoResponse {
-  // This field is REQUIRED.
+  // Specify the name in Reverse domain name notation format,
+  // (https://en.wikipedia.org/wiki/Reverse_domain_name_notation)
+  // which includes the plugin's host company name and the plugin name,
+  // to minimize the possibility of collisions. The field MUST be 63
+  // characters or less, beginning and ending with an alphanumeric
+  // character ([a-z0-9A-Z]) with dashes (-), underscores (_),
+  // dots (.), and alphanumerics between. This field is REQUIRED.
   string name = 1;
 
   // This field is REQUIRED. Value of this field is opaque to the CO.


### PR DESCRIPTION
The plugin name will be passed in through CO's
APIs by the users to refer to the plugin.
CSI should clarify the plugin name rules.
This patch sepecifies the name in Reverse domain
name notation format.

Resolves: #145, #3