### PR TITLE
Go Bindings Canonical Import Path

### DIFF
--- a/lib/go/Makefile
+++ b/lib/go/Makefile
@@ -80,11 +80,13 @@ CSI_GO := csi/csi.pb.go
 CSI_A := csi.a
 CSI_PROTO := ../../csi.proto
 CSI_GO_TMP := csi/.build/csi.pb.go
+CSI_CANON_IMPORT := github.com/container-storage-interface/spec/lib/go/csi
 
 # This recipe generates the go language bindings to a temp area.
 $(CSI_GO_TMP): $(CSI_PROTO) | $(PROTOC) $(PROTOC_GEN_GO)
 	@mkdir -p "$(@D)"
 	$(PROTOC) -I "$(<D)" --go_out=plugins=grpc:"$(@D)" "$<"
+	sed -i -e 's|package csi|package csi // import "$(CSI_CANON_IMPORT)"|g' "$@"
 
 # The temp language bindings are compared to the ones that are
 # versioned. If they are different then it means the language

--- a/lib/go/csi/csi.pb.go
+++ b/lib/go/csi/csi.pb.go
@@ -47,7 +47,7 @@ It has these top-level messages:
 	NodeGetCapabilitiesResponse
 	NodeServiceCapability
 */
-package csi
+package csi // import "github.com/container-storage-interface/spec/lib/go/csi"
 
 import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"


### PR DESCRIPTION
This patch fixes #142 and adds a Go canonical import path of "github.com/container-storage-interface/spec/lib/go/csi" to the CSI Go bindings.

@jdef @saad-ali 