### PR TITLE
Remove all SP Implementation Info

### DIFF
--- a/csi.proto
+++ b/csi.proto
@@ -270,12 +270,12 @@ message VolumeCapability {
 message CapacityRange {
   // Volume must be at least this big. This field is OPTIONAL.
   // A value of 0 is equal to an unspecified field value.
-  // The value of this field MUST NOT be negative. 
+  // The value of this field MUST NOT be negative.
   int64 required_bytes = 1;
 
   // Volume must not be bigger than this. This field is OPTIONAL.
   // A value of 0 is equal to an unspecified field value.
-  // The value of this field MUST NOT be negative. 
+  // The value of this field MUST NOT be negative.
   int64 limit_bytes = 2;
 }
 
@@ -284,7 +284,7 @@ message Volume {
   // The capacity of the volume in bytes. This field is OPTIONAL. If not
   // set (value of 0), it indicates that the capacity of the volume is
   // unknown (e.g., NFS share).
-  // The value of this field MUST NOT be negative. 
+  // The value of this field MUST NOT be negative.
   int64 capacity_bytes = 1;
 
   // Contains identity information for the created volume. This field is
@@ -447,7 +447,7 @@ message ListVolumesRequest {
   // in the subsequent `ListVolumes` call. This field is OPTIONAL. If
   // not specified (zero value), it means there is no restriction on the
   // number of entries that can be returned.
-  // The value of this field MUST NOT be negative. 
+  // The value of this field MUST NOT be negative.
   int32 max_entries = 2;
 
   // A token to specify where to start paginating. Set this field to
@@ -498,7 +498,7 @@ message GetCapacityResponse {
   // specified in the request, the Plugin SHALL take those into
   // consideration when calculating the available capacity of the
   // storage. This field is REQUIRED.
-  // The value of this field MUST NOT be negative. 
+  // The value of this field MUST NOT be negative.
   int64 available_capacity = 1;
 }
 ////////


### PR DESCRIPTION
This patch removes all of the SP implementation information previously detailed in the specification. With respect to issue #171 and comments made by @saad-ali, @childsb, @jdef, and others, it has become apparent that the specification should not supply any suggestions or restrictions on matters related to an SP's packaging, deployment, or runtime configuration.

Removed information includes, but is not limited to the following:

| Removed | Description |
|----------|-------------|
| `CSI_ENDPOINT` | SPs are now responsible for defining the manner by which they grok the gRPC endpoint on which they serve the CSI services. CO admins are now responsible for deploying and configuring SPs using that SP's documentation. |
| Environment variable names | The spec no longer claims ownership of the `CSI_` prefix for environment variables. |
| Permissions | The spec no longer asserts any recommendations with respect to container permissions that an SP might require. |
| Logging | All logging details are the responsibility of the SP and may vary SP to SP. |

As a reminder, the above list is not exhaustive or complete. Please see the patch for the full picture.

# Guide to Developing CSI Storage Plug-ins
The removed information may very well be suitable to live in a separate document that provides guidelines for SP creation and configuration, such as common environment variable names, logging and packaging details, etc.

cc @codenrhoden