### PR TITLE
spec: Remove a reference to VolumeInfo

### DIFF
--- a/csi.proto
+++ b/csi.proto
@@ -544,7 +544,7 @@ message NodeStageVolumeRequest {
   map<string, string> node_stage_secrets = 5;
 
   // Attributes of the volume to publish. This field is OPTIONAL and
-  // MUST match the attributes of the VolumeInfo identified by
+  // MUST match the attributes of the `Volume` identified by
   // `volume_id`.
   map<string,string> volume_attributes = 6;
 }

--- a/csi.proto
+++ b/csi.proto
@@ -278,7 +278,7 @@ message Volume {
   // a volume. A volume uniquely identified by `id` SHALL always report
   // the same attributes. This field is OPTIONAL and when present MUST
   // be passed to volume validation and publishing calls.
-  map<string,string> attributes = 3;
+  map<string, string> attributes = 3;
 }
 message DeleteVolumeRequest {
   // The ID of the volume to be deprovisioned.
@@ -347,7 +347,7 @@ message ControllerPublishVolumeRequest {
   // Attributes of the volume to be used on a node. This field is
   // OPTIONAL and MUST match the attributes of the Volume identified
   // by `volume_id`.
-  map<string,string> volume_attributes = 6;
+  map<string, string> volume_attributes = 6;
 }
 
 message ControllerPublishVolumeResponse {
@@ -404,7 +404,7 @@ message ValidateVolumeCapabilitiesRequest {
 
   // Attributes of the volume to check. This field is OPTIONAL and MUST
   // match the attributes of the Volume identified by `volume_id`.
-  map<string,string> volume_attributes = 3;
+  map<string, string> volume_attributes = 3;
 }
 
 message ValidateVolumeCapabilitiesResponse {
@@ -546,7 +546,7 @@ message NodeStageVolumeRequest {
   // Attributes of the volume to publish. This field is OPTIONAL and
   // MUST match the attributes of the `Volume` identified by
   // `volume_id`.
-  map<string,string> volume_attributes = 6;
+  map<string, string> volume_attributes = 6;
 }
 
 message NodeStageVolumeResponse {
@@ -620,7 +620,7 @@ message NodePublishVolumeRequest {
   // Attributes of the volume to publish. This field is OPTIONAL and
   // MUST match the attributes of the Volume identified by
   // `volume_id`.
-  map<string,string> volume_attributes = 8;
+  map<string, string> volume_attributes = 8;
 }
 
 message NodePublishVolumeResponse {

--- a/lib/go/csi/v0/csi.pb.go
+++ b/lib/go/csi/v0/csi.pb.go
@@ -288,7 +288,9 @@ func (m *PluginCapability) String() string            { return proto.CompactText
 func (*PluginCapability) ProtoMessage()               {}
 func (*PluginCapability) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{4} }
 
-type isPluginCapability_Type interface{ isPluginCapability_Type() }
+type isPluginCapability_Type interface {
+	isPluginCapability_Type()
+}
 
 type PluginCapability_Service_ struct {
 	Service *PluginCapability_Service `protobuf:"bytes,1,opt,name=service,oneof"`
@@ -528,7 +530,9 @@ func (m *VolumeCapability) String() string            { return proto.CompactText
 func (*VolumeCapability) ProtoMessage()               {}
 func (*VolumeCapability) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{9} }
 
-type isVolumeCapability_AccessType interface{ isVolumeCapability_AccessType() }
+type isVolumeCapability_AccessType interface {
+	isVolumeCapability_AccessType()
+}
 
 type VolumeCapability_Block struct {
 	Block *VolumeCapability_BlockVolume `protobuf:"bytes,1,opt,name=block,oneof"`
@@ -1260,7 +1264,9 @@ func (m *ControllerServiceCapability) String() string            { return proto.
 func (*ControllerServiceCapability) ProtoMessage()               {}
 func (*ControllerServiceCapability) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{26} }
 
-type isControllerServiceCapability_Type interface{ isControllerServiceCapability_Type() }
+type isControllerServiceCapability_Type interface {
+	isControllerServiceCapability_Type()
+}
 
 type ControllerServiceCapability_Rpc struct {
 	Rpc *ControllerServiceCapability_RPC `protobuf:"bytes,1,opt,name=rpc,oneof"`
@@ -1711,7 +1717,9 @@ func (m *NodeServiceCapability) String() string            { return proto.Compac
 func (*NodeServiceCapability) ProtoMessage()               {}
 func (*NodeServiceCapability) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{39} }
 
-type isNodeServiceCapability_Type interface{ isNodeServiceCapability_Type() }
+type isNodeServiceCapability_Type interface {
+	isNodeServiceCapability_Type()
+}
 
 type NodeServiceCapability_Rpc struct {
 	Rpc *NodeServiceCapability_RPC `protobuf:"bytes,1,opt,name=rpc,oneof"`

--- a/lib/go/csi/v0/csi.pb.go
+++ b/lib/go/csi/v0/csi.pb.go
@@ -288,9 +288,7 @@ func (m *PluginCapability) String() string            { return proto.CompactText
 func (*PluginCapability) ProtoMessage()               {}
 func (*PluginCapability) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{4} }
 
-type isPluginCapability_Type interface {
-	isPluginCapability_Type()
-}
+type isPluginCapability_Type interface{ isPluginCapability_Type() }
 
 type PluginCapability_Service_ struct {
 	Service *PluginCapability_Service `protobuf:"bytes,1,opt,name=service,oneof"`
@@ -530,9 +528,7 @@ func (m *VolumeCapability) String() string            { return proto.CompactText
 func (*VolumeCapability) ProtoMessage()               {}
 func (*VolumeCapability) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{9} }
 
-type isVolumeCapability_AccessType interface {
-	isVolumeCapability_AccessType()
-}
+type isVolumeCapability_AccessType interface{ isVolumeCapability_AccessType() }
 
 type VolumeCapability_Block struct {
 	Block *VolumeCapability_BlockVolume `protobuf:"bytes,1,opt,name=block,oneof"`
@@ -1264,9 +1260,7 @@ func (m *ControllerServiceCapability) String() string            { return proto.
 func (*ControllerServiceCapability) ProtoMessage()               {}
 func (*ControllerServiceCapability) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{26} }
 
-type isControllerServiceCapability_Type interface {
-	isControllerServiceCapability_Type()
-}
+type isControllerServiceCapability_Type interface{ isControllerServiceCapability_Type() }
 
 type ControllerServiceCapability_Rpc struct {
 	Rpc *ControllerServiceCapability_RPC `protobuf:"bytes,1,opt,name=rpc,oneof"`
@@ -1398,7 +1392,7 @@ type NodeStageVolumeRequest struct {
 	// This field is OPTIONAL.
 	NodeStageSecrets map[string]string `protobuf:"bytes,5,rep,name=node_stage_secrets,json=nodeStageSecrets" json:"node_stage_secrets,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	// Attributes of the volume to publish. This field is OPTIONAL and
-	// MUST match the attributes of the VolumeInfo identified by
+	// MUST match the attributes of the `Volume` identified by
 	// `volume_id`.
 	VolumeAttributes map[string]string `protobuf:"bytes,6,rep,name=volume_attributes,json=volumeAttributes" json:"volume_attributes,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 }
@@ -1717,9 +1711,7 @@ func (m *NodeServiceCapability) String() string            { return proto.Compac
 func (*NodeServiceCapability) ProtoMessage()               {}
 func (*NodeServiceCapability) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{39} }
 
-type isNodeServiceCapability_Type interface {
-	isNodeServiceCapability_Type()
-}
+type isNodeServiceCapability_Type interface{ isNodeServiceCapability_Type() }
 
 type NodeServiceCapability_Rpc struct {
 	Rpc *NodeServiceCapability_RPC `protobuf:"bytes,1,opt,name=rpc,oneof"`

--- a/spec.md
+++ b/spec.md
@@ -1164,7 +1164,7 @@ message NodeStageVolumeRequest {
   map<string, string> node_stage_secrets = 5;
 
   // Attributes of the volume to publish. This field is OPTIONAL and
-  // MUST match the attributes of the VolumeInfo identified by
+  // MUST match the attributes of the `Volume` identified by
   // `volume_id`.
   map<string,string> volume_attributes = 6;
 }

--- a/spec.md
+++ b/spec.md
@@ -698,7 +698,7 @@ message Volume {
   // a volume. A volume uniquely identified by `id` SHALL always report
   // the same attributes. This field is OPTIONAL and when present MUST
   // be passed to volume validation and publishing calls.
-  map<string,string> attributes = 3;
+  map<string, string> attributes = 3;
 }
 ```
 
@@ -823,7 +823,7 @@ message ControllerPublishVolumeRequest {
   // Attributes of the volume to be used on a node. This field is
   // OPTIONAL and MUST match the attributes of the Volume identified
   // by `volume_id`.
-  map<string,string> volume_attributes = 6;
+  map<string, string> volume_attributes = 6;
 }
 
 message ControllerPublishVolumeResponse {
@@ -937,7 +937,7 @@ message ValidateVolumeCapabilitiesRequest {
 
   // Attributes of the volume to check. This field is OPTIONAL and MUST
   // match the attributes of the Volume identified by `volume_id`.
-  map<string,string> volume_attributes = 3;
+  map<string, string> volume_attributes = 3;
 }
 
 message ValidateVolumeCapabilitiesResponse {
@@ -1166,7 +1166,7 @@ message NodeStageVolumeRequest {
   // Attributes of the volume to publish. This field is OPTIONAL and
   // MUST match the attributes of the `Volume` identified by
   // `volume_id`.
-  map<string,string> volume_attributes = 6;
+  map<string, string> volume_attributes = 6;
 }
 
 message NodeStageVolumeResponse {
@@ -1321,7 +1321,7 @@ message NodePublishVolumeRequest {
   // Attributes of the volume to publish. This field is OPTIONAL and
   // MUST match the attributes of the Volume identified by
   // `volume_id`.
-  map<string,string> volume_attributes = 8;
+  map<string, string> volume_attributes = 8;
 }
 
 message NodePublishVolumeResponse {


### PR DESCRIPTION
VolumeInfo has been renamed to Volume in the spec. This patch fixed a
reference to VolumeInfo in the spec.