### PR TITLE
lib/go: pin golang/protobuf dep to v1.1.0

### DIFF
--- a/lib/go/Makefile
+++ b/lib/go/Makefile
@@ -58,8 +58,15 @@ $(PROTOC):
 # for protoc
 PROTOC_GEN_GO_PKG := github.com/golang/protobuf/protoc-gen-go
 PROTOC_GEN_GO := protoc-gen-go
+$(PROTOC_GEN_GO): PROTOBUF_PKG := $(dir $(PROTOC_GEN_GO_PKG))
+$(PROTOC_GEN_GO): PROTOBUF_VERSION := v1.1.0
 $(PROTOC_GEN_GO):
-	go get -d $(PROTOC_GEN_GO_PKG) && \
+	mkdir -p $(dir $(GOPATH)/src/$(PROTOBUF_PKG))
+	test -d $(GOPATH)/src/$(PROTOBUF_PKG)/.git || git clone https://$(PROTOBUF_PKG) $(GOPATH)/src/$(PROTOBUF_PKG)
+	(cd $(GOPATH)/src/$(PROTOBUF_PKG) && \
+		(test "$$(git describe --tags | head -1)" = "$(PROTOBUF_VERSION)" || \
+			(git fetch && git checkout tags/$(PROTOBUF_VERSION))))
+	(cd $(GOPATH)/src/$(PROTOBUF_PKG) && go get -v -d ./...) && \
 	go build -o "$@" $(PROTOC_GEN_GO_PKG)
 
 
@@ -104,7 +111,7 @@ endif
 #   2. Cache the packages.
 #   3. Build the archive file.
 $(CSI_A): $(CSI_GO)
-	go get -d ./...
+	go get -v -d ./...
 	go install ./$(CSI_PKG)
 	go build -o "$@" ./$(CSI_PKG)
 


### PR DESCRIPTION
The golang/protobuf master branch broke our CI builds again, just a few days after the last breakage. This PR aims to apply a better band-aid by pinning CSI CI builds to a specific release of the golang/protobuf library.