### PR TITLE
Updating prefix formats

### DIFF
--- a/csi.proto
+++ b/csi.proto
@@ -89,13 +89,13 @@ message GetPluginInfoRequest {
 }
 
 message GetPluginInfoResponse {
-  // The name MUST follow reverse domain name notation format
-  // (https://en.wikipedia.org/wiki/Reverse_domain_name_notation).
-  // It SHOULD include the plugin's host company name and the plugin
-  // name, to minimize the possibility of collisions. It MUST be 63
+  // The name MUST follow domain name notation format
+  // (https://tools.ietf.org/html/rfc1035#section-2.3.1). It SHOULD
+  // include the plugin's host company name and the plugin name,
+  // to minimize the possibility of collisions. It MUST be 63
   // characters or less, beginning and ending with an alphanumeric
-  // character ([a-z0-9A-Z]) with dashes (-), underscores (_),
-  // dots (.), and alphanumerics between. This field is REQUIRED.
+  // character ([a-z0-9A-Z]) with dashes (-), dots (.), and
+  // alphanumerics between. This field is REQUIRED.
   string name = 1;
 
   // This field is REQUIRED. Value of this field is opaque to the CO.
@@ -533,12 +533,15 @@ message TopologyRequirement {
 // Valid keys have two segments: an optional prefix and name, separated
 // by a slash (/), for example: "com.company.example/zone".
 // The key name segment is required. The prefix is optional.
-// Both the key name and the prefix MUST each be 63 characters or less,
-// begin and end with an alphanumeric character ([a-z0-9A-Z]) and
-// contain only dashes (-), underscores (_), dots (.), or alphanumerics
-// in between, for example "zone".
-// The key prefix MUST follow reverse domain name notation format
-// (https://en.wikipedia.org/wiki/Reverse_domain_name_notation).
+// The key name MUST be 63 characters or less, begin and end with an
+// alphanumeric character ([a-z0-9A-Z]), and contain only dashes (-),
+// underscores (_), dots (.), or alphanumerics in between, for example
+// "zone".
+// The key prefix MUST be 63 characters or less, begin and end with a
+// lower-case alphanumeric character ([a-z0-9]), contain only
+// dashes (-), dots (.), or lower-case alphanumerics in between, and
+// follow domain name notation format
+// (https://tools.ietf.org/html/rfc1035#section-2.3.1).
 // The key prefix SHOULD include the plugin's host company name and/or
 // the plugin name, to minimize the possibility of collisions with keys
 // from other plugins.

--- a/lib/go/csi/v0/csi.pb.go
+++ b/lib/go/csi/v0/csi.pb.go
@@ -61,7 +61,7 @@ func (x PluginCapability_Service_Type) String() string {
 	return proto.EnumName(PluginCapability_Service_Type_name, int32(x))
 }
 func (PluginCapability_Service_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{4, 0, 0}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{4, 0, 0}
 }
 
 type VolumeCapability_AccessMode_Mode int32
@@ -105,7 +105,7 @@ func (x VolumeCapability_AccessMode_Mode) String() string {
 	return proto.EnumName(VolumeCapability_AccessMode_Mode_name, int32(x))
 }
 func (VolumeCapability_AccessMode_Mode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{10, 2, 0}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{10, 2, 0}
 }
 
 type ControllerServiceCapability_RPC_Type int32
@@ -151,7 +151,7 @@ func (x ControllerServiceCapability_RPC_Type) String() string {
 	return proto.EnumName(ControllerServiceCapability_RPC_Type_name, int32(x))
 }
 func (ControllerServiceCapability_RPC_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{29, 0, 0}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{29, 0, 0}
 }
 
 type SnapshotStatus_Type int32
@@ -193,7 +193,7 @@ func (x SnapshotStatus_Type) String() string {
 	return proto.EnumName(SnapshotStatus_Type_name, int32(x))
 }
 func (SnapshotStatus_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{33, 0}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{33, 0}
 }
 
 type VolumeUsage_Unit int32
@@ -219,7 +219,7 @@ func (x VolumeUsage_Unit) String() string {
 	return proto.EnumName(VolumeUsage_Unit_name, int32(x))
 }
 func (VolumeUsage_Unit) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{48, 0}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{48, 0}
 }
 
 type NodeServiceCapability_RPC_Type int32
@@ -248,7 +248,7 @@ func (x NodeServiceCapability_RPC_Type) String() string {
 	return proto.EnumName(NodeServiceCapability_RPC_Type_name, int32(x))
 }
 func (NodeServiceCapability_RPC_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{53, 0, 0}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{53, 0, 0}
 }
 
 type GetPluginInfoRequest struct {
@@ -261,7 +261,7 @@ func (m *GetPluginInfoRequest) Reset()         { *m = GetPluginInfoRequest{} }
 func (m *GetPluginInfoRequest) String() string { return proto.CompactTextString(m) }
 func (*GetPluginInfoRequest) ProtoMessage()    {}
 func (*GetPluginInfoRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{0}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{0}
 }
 func (m *GetPluginInfoRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetPluginInfoRequest.Unmarshal(m, b)
@@ -282,13 +282,13 @@ func (m *GetPluginInfoRequest) XXX_DiscardUnknown() {
 var xxx_messageInfo_GetPluginInfoRequest proto.InternalMessageInfo
 
 type GetPluginInfoResponse struct {
-	// The name MUST follow reverse domain name notation format
-	// (https://en.wikipedia.org/wiki/Reverse_domain_name_notation).
-	// It SHOULD include the plugin's host company name and the plugin
-	// name, to minimize the possibility of collisions. It MUST be 63
+	// The name MUST follow domain name notation format
+	// (https://tools.ietf.org/html/rfc1035#section-2.3.1). It SHOULD
+	// include the plugin's host company name and the plugin name,
+	// to minimize the possibility of collisions. It MUST be 63
 	// characters or less, beginning and ending with an alphanumeric
-	// character ([a-z0-9A-Z]) with dashes (-), underscores (_),
-	// dots (.), and alphanumerics between. This field is REQUIRED.
+	// character ([a-z0-9A-Z]) with dashes (-), dots (.), and
+	// alphanumerics between. This field is REQUIRED.
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// This field is REQUIRED. Value of this field is opaque to the CO.
 	VendorVersion string `protobuf:"bytes,2,opt,name=vendor_version,json=vendorVersion,proto3" json:"vendor_version,omitempty"`
@@ -303,7 +303,7 @@ func (m *GetPluginInfoResponse) Reset()         { *m = GetPluginInfoResponse{} }
 func (m *GetPluginInfoResponse) String() string { return proto.CompactTextString(m) }
 func (*GetPluginInfoResponse) ProtoMessage()    {}
 func (*GetPluginInfoResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{1}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{1}
 }
 func (m *GetPluginInfoResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetPluginInfoResponse.Unmarshal(m, b)
@@ -354,7 +354,7 @@ func (m *GetPluginCapabilitiesRequest) Reset()         { *m = GetPluginCapabilit
 func (m *GetPluginCapabilitiesRequest) String() string { return proto.CompactTextString(m) }
 func (*GetPluginCapabilitiesRequest) ProtoMessage()    {}
 func (*GetPluginCapabilitiesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{2}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{2}
 }
 func (m *GetPluginCapabilitiesRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetPluginCapabilitiesRequest.Unmarshal(m, b)
@@ -387,7 +387,7 @@ func (m *GetPluginCapabilitiesResponse) Reset()         { *m = GetPluginCapabili
 func (m *GetPluginCapabilitiesResponse) String() string { return proto.CompactTextString(m) }
 func (*GetPluginCapabilitiesResponse) ProtoMessage()    {}
 func (*GetPluginCapabilitiesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{3}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{3}
 }
 func (m *GetPluginCapabilitiesResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetPluginCapabilitiesResponse.Unmarshal(m, b)
@@ -428,7 +428,7 @@ func (m *PluginCapability) Reset()         { *m = PluginCapability{} }
 func (m *PluginCapability) String() string { return proto.CompactTextString(m) }
 func (*PluginCapability) ProtoMessage()    {}
 func (*PluginCapability) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{4}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{4}
 }
 func (m *PluginCapability) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PluginCapability.Unmarshal(m, b)
@@ -538,7 +538,7 @@ func (m *PluginCapability_Service) Reset()         { *m = PluginCapability_Servi
 func (m *PluginCapability_Service) String() string { return proto.CompactTextString(m) }
 func (*PluginCapability_Service) ProtoMessage()    {}
 func (*PluginCapability_Service) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{4, 0}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{4, 0}
 }
 func (m *PluginCapability_Service) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PluginCapability_Service.Unmarshal(m, b)
@@ -575,7 +575,7 @@ func (m *ProbeRequest) Reset()         { *m = ProbeRequest{} }
 func (m *ProbeRequest) String() string { return proto.CompactTextString(m) }
 func (*ProbeRequest) ProtoMessage()    {}
 func (*ProbeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{5}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{5}
 }
 func (m *ProbeRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ProbeRequest.Unmarshal(m, b)
@@ -626,7 +626,7 @@ func (m *ProbeResponse) Reset()         { *m = ProbeResponse{} }
 func (m *ProbeResponse) String() string { return proto.CompactTextString(m) }
 func (*ProbeResponse) ProtoMessage()    {}
 func (*ProbeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{6}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{6}
 }
 func (m *ProbeResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ProbeResponse.Unmarshal(m, b)
@@ -712,7 +712,7 @@ func (m *CreateVolumeRequest) Reset()         { *m = CreateVolumeRequest{} }
 func (m *CreateVolumeRequest) String() string { return proto.CompactTextString(m) }
 func (*CreateVolumeRequest) ProtoMessage()    {}
 func (*CreateVolumeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{7}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{7}
 }
 func (m *CreateVolumeRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CreateVolumeRequest.Unmarshal(m, b)
@@ -796,7 +796,7 @@ func (m *VolumeContentSource) Reset()         { *m = VolumeContentSource{} }
 func (m *VolumeContentSource) String() string { return proto.CompactTextString(m) }
 func (*VolumeContentSource) ProtoMessage()    {}
 func (*VolumeContentSource) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{8}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{8}
 }
 func (m *VolumeContentSource) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VolumeContentSource.Unmarshal(m, b)
@@ -910,7 +910,7 @@ func (m *VolumeContentSource_SnapshotSource) Reset()         { *m = VolumeConten
 func (m *VolumeContentSource_SnapshotSource) String() string { return proto.CompactTextString(m) }
 func (*VolumeContentSource_SnapshotSource) ProtoMessage()    {}
 func (*VolumeContentSource_SnapshotSource) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{8, 0}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{8, 0}
 }
 func (m *VolumeContentSource_SnapshotSource) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VolumeContentSource_SnapshotSource.Unmarshal(m, b)
@@ -951,7 +951,7 @@ func (m *CreateVolumeResponse) Reset()         { *m = CreateVolumeResponse{} }
 func (m *CreateVolumeResponse) String() string { return proto.CompactTextString(m) }
 func (*CreateVolumeResponse) ProtoMessage()    {}
 func (*CreateVolumeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{9}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{9}
 }
 func (m *CreateVolumeResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CreateVolumeResponse.Unmarshal(m, b)
@@ -998,7 +998,7 @@ func (m *VolumeCapability) Reset()         { *m = VolumeCapability{} }
 func (m *VolumeCapability) String() string { return proto.CompactTextString(m) }
 func (*VolumeCapability) ProtoMessage()    {}
 func (*VolumeCapability) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{10}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{10}
 }
 func (m *VolumeCapability) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VolumeCapability.Unmarshal(m, b)
@@ -1147,7 +1147,7 @@ func (m *VolumeCapability_BlockVolume) Reset()         { *m = VolumeCapability_B
 func (m *VolumeCapability_BlockVolume) String() string { return proto.CompactTextString(m) }
 func (*VolumeCapability_BlockVolume) ProtoMessage()    {}
 func (*VolumeCapability_BlockVolume) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{10, 0}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{10, 0}
 }
 func (m *VolumeCapability_BlockVolume) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VolumeCapability_BlockVolume.Unmarshal(m, b)
@@ -1187,7 +1187,7 @@ func (m *VolumeCapability_MountVolume) Reset()         { *m = VolumeCapability_M
 func (m *VolumeCapability_MountVolume) String() string { return proto.CompactTextString(m) }
 func (*VolumeCapability_MountVolume) ProtoMessage()    {}
 func (*VolumeCapability_MountVolume) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{10, 1}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{10, 1}
 }
 func (m *VolumeCapability_MountVolume) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VolumeCapability_MountVolume.Unmarshal(m, b)
@@ -1234,7 +1234,7 @@ func (m *VolumeCapability_AccessMode) Reset()         { *m = VolumeCapability_Ac
 func (m *VolumeCapability_AccessMode) String() string { return proto.CompactTextString(m) }
 func (*VolumeCapability_AccessMode) ProtoMessage()    {}
 func (*VolumeCapability_AccessMode) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{10, 2}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{10, 2}
 }
 func (m *VolumeCapability_AccessMode) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VolumeCapability_AccessMode.Unmarshal(m, b)
@@ -1282,7 +1282,7 @@ func (m *CapacityRange) Reset()         { *m = CapacityRange{} }
 func (m *CapacityRange) String() string { return proto.CompactTextString(m) }
 func (*CapacityRange) ProtoMessage()    {}
 func (*CapacityRange) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{11}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{11}
 }
 func (m *CapacityRange) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CapacityRange.Unmarshal(m, b)
@@ -1375,7 +1375,7 @@ func (m *Volume) Reset()         { *m = Volume{} }
 func (m *Volume) String() string { return proto.CompactTextString(m) }
 func (*Volume) ProtoMessage()    {}
 func (*Volume) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{12}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{12}
 }
 func (m *Volume) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Volume.Unmarshal(m, b)
@@ -1567,7 +1567,7 @@ func (m *TopologyRequirement) Reset()         { *m = TopologyRequirement{} }
 func (m *TopologyRequirement) String() string { return proto.CompactTextString(m) }
 func (*TopologyRequirement) ProtoMessage()    {}
 func (*TopologyRequirement) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{13}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{13}
 }
 func (m *TopologyRequirement) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_TopologyRequirement.Unmarshal(m, b)
@@ -1610,12 +1610,15 @@ func (m *TopologyRequirement) GetPreferred() []*Topology {
 // Valid keys have two segments: an optional prefix and name, separated
 // by a slash (/), for example: "com.company.example/zone".
 // The key name segment is required. The prefix is optional.
-// Both the key name and the prefix MUST each be 63 characters or less,
-// begin and end with an alphanumeric character ([a-z0-9A-Z]) and
-// contain only dashes (-), underscores (_), dots (.), or alphanumerics
-// in between, for example "zone".
-// The key prefix MUST follow reverse domain name notation format
-// (https://en.wikipedia.org/wiki/Reverse_domain_name_notation).
+// The key name MUST be 63 characters or less, begin and end with an
+// alphanumeric character ([a-z0-9A-Z]), and contain only dashes (-),
+// underscores (_), dots (.), or alphanumerics in between, for example
+// "zone".
+// The key prefix MUST be 63 characters or less, begin and end with a
+// lower-case alphanumeric character ([a-z0-9]), contain only
+// dashes (-), dots (.), or lower-case alphanumerics in between, and
+// follow domain name notation format
+// (https://tools.ietf.org/html/rfc1035#section-2.3.1).
 // The key prefix SHOULD include the plugin's host company name and/or
 // the plugin name, to minimize the possibility of collisions with keys
 // from other plugins.
@@ -1638,7 +1641,7 @@ func (m *Topology) Reset()         { *m = Topology{} }
 func (m *Topology) String() string { return proto.CompactTextString(m) }
 func (*Topology) ProtoMessage()    {}
 func (*Topology) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{14}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{14}
 }
 func (m *Topology) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Topology.Unmarshal(m, b)
@@ -1682,7 +1685,7 @@ func (m *DeleteVolumeRequest) Reset()         { *m = DeleteVolumeRequest{} }
 func (m *DeleteVolumeRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteVolumeRequest) ProtoMessage()    {}
 func (*DeleteVolumeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{15}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{15}
 }
 func (m *DeleteVolumeRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeleteVolumeRequest.Unmarshal(m, b)
@@ -1726,7 +1729,7 @@ func (m *DeleteVolumeResponse) Reset()         { *m = DeleteVolumeResponse{} }
 func (m *DeleteVolumeResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteVolumeResponse) ProtoMessage()    {}
 func (*DeleteVolumeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{16}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{16}
 }
 func (m *DeleteVolumeResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeleteVolumeResponse.Unmarshal(m, b)
@@ -1776,7 +1779,7 @@ func (m *ControllerPublishVolumeRequest) Reset()         { *m = ControllerPublis
 func (m *ControllerPublishVolumeRequest) String() string { return proto.CompactTextString(m) }
 func (*ControllerPublishVolumeRequest) ProtoMessage()    {}
 func (*ControllerPublishVolumeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{17}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{17}
 }
 func (m *ControllerPublishVolumeRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ControllerPublishVolumeRequest.Unmarshal(m, b)
@@ -1853,7 +1856,7 @@ func (m *ControllerPublishVolumeResponse) Reset()         { *m = ControllerPubli
 func (m *ControllerPublishVolumeResponse) String() string { return proto.CompactTextString(m) }
 func (*ControllerPublishVolumeResponse) ProtoMessage()    {}
 func (*ControllerPublishVolumeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{18}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{18}
 }
 func (m *ControllerPublishVolumeResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ControllerPublishVolumeResponse.Unmarshal(m, b)
@@ -1904,7 +1907,7 @@ func (m *ControllerUnpublishVolumeRequest) Reset()         { *m = ControllerUnpu
 func (m *ControllerUnpublishVolumeRequest) String() string { return proto.CompactTextString(m) }
 func (*ControllerUnpublishVolumeRequest) ProtoMessage()    {}
 func (*ControllerUnpublishVolumeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{19}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{19}
 }
 func (m *ControllerUnpublishVolumeRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ControllerUnpublishVolumeRequest.Unmarshal(m, b)
@@ -1955,7 +1958,7 @@ func (m *ControllerUnpublishVolumeResponse) Reset()         { *m = ControllerUnp
 func (m *ControllerUnpublishVolumeResponse) String() string { return proto.CompactTextString(m) }
 func (*ControllerUnpublishVolumeResponse) ProtoMessage()    {}
 func (*ControllerUnpublishVolumeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{20}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{20}
 }
 func (m *ControllerUnpublishVolumeResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ControllerUnpublishVolumeResponse.Unmarshal(m, b)
@@ -2001,7 +2004,7 @@ func (m *ValidateVolumeCapabilitiesRequest) Reset()         { *m = ValidateVolum
 func (m *ValidateVolumeCapabilitiesRequest) String() string { return proto.CompactTextString(m) }
 func (*ValidateVolumeCapabilitiesRequest) ProtoMessage()    {}
 func (*ValidateVolumeCapabilitiesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{21}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{21}
 }
 func (m *ValidateVolumeCapabilitiesRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ValidateVolumeCapabilitiesRequest.Unmarshal(m, b)
@@ -2066,7 +2069,7 @@ func (m *ValidateVolumeCapabilitiesResponse) Reset()         { *m = ValidateVolu
 func (m *ValidateVolumeCapabilitiesResponse) String() string { return proto.CompactTextString(m) }
 func (*ValidateVolumeCapabilitiesResponse) ProtoMessage()    {}
 func (*ValidateVolumeCapabilitiesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{22}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{22}
 }
 func (m *ValidateVolumeCapabilitiesResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ValidateVolumeCapabilitiesResponse.Unmarshal(m, b)
@@ -2124,7 +2127,7 @@ func (m *ListVolumesRequest) Reset()         { *m = ListVolumesRequest{} }
 func (m *ListVolumesRequest) String() string { return proto.CompactTextString(m) }
 func (*ListVolumesRequest) ProtoMessage()    {}
 func (*ListVolumesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{23}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{23}
 }
 func (m *ListVolumesRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListVolumesRequest.Unmarshal(m, b)
@@ -2176,7 +2179,7 @@ func (m *ListVolumesResponse) Reset()         { *m = ListVolumesResponse{} }
 func (m *ListVolumesResponse) String() string { return proto.CompactTextString(m) }
 func (*ListVolumesResponse) ProtoMessage()    {}
 func (*ListVolumesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{24}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{24}
 }
 func (m *ListVolumesResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListVolumesResponse.Unmarshal(m, b)
@@ -2221,7 +2224,7 @@ func (m *ListVolumesResponse_Entry) Reset()         { *m = ListVolumesResponse_E
 func (m *ListVolumesResponse_Entry) String() string { return proto.CompactTextString(m) }
 func (*ListVolumesResponse_Entry) ProtoMessage()    {}
 func (*ListVolumesResponse_Entry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{24, 0}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{24, 0}
 }
 func (m *ListVolumesResponse_Entry) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListVolumesResponse_Entry.Unmarshal(m, b)
@@ -2276,7 +2279,7 @@ func (m *GetCapacityRequest) Reset()         { *m = GetCapacityRequest{} }
 func (m *GetCapacityRequest) String() string { return proto.CompactTextString(m) }
 func (*GetCapacityRequest) ProtoMessage()    {}
 func (*GetCapacityRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{25}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{25}
 }
 func (m *GetCapacityRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetCapacityRequest.Unmarshal(m, b)
@@ -2334,7 +2337,7 @@ func (m *GetCapacityResponse) Reset()         { *m = GetCapacityResponse{} }
 func (m *GetCapacityResponse) String() string { return proto.CompactTextString(m) }
 func (*GetCapacityResponse) ProtoMessage()    {}
 func (*GetCapacityResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{26}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{26}
 }
 func (m *GetCapacityResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GetCapacityResponse.Unmarshal(m, b)
@@ -2371,7 +2374,7 @@ func (m *ControllerGetCapabilitiesRequest) Reset()         { *m = ControllerGetC
 func (m *ControllerGetCapabilitiesRequest) String() string { return proto.CompactTextString(m) }
 func (*ControllerGetCapabilitiesRequest) ProtoMessage()    {}
 func (*ControllerGetCapabilitiesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{27}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{27}
 }
 func (m *ControllerGetCapabilitiesRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ControllerGetCapabilitiesRequest.Unmarshal(m, b)
@@ -2404,7 +2407,7 @@ func (m *ControllerGetCapabilitiesResponse) Reset()         { *m = ControllerGet
 func (m *ControllerGetCapabilitiesResponse) String() string { return proto.CompactTextString(m) }
 func (*ControllerGetCapabilitiesResponse) ProtoMessage()    {}
 func (*ControllerGetCapabilitiesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{28}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{28}
 }
 func (m *ControllerGetCapabilitiesResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ControllerGetCapabilitiesResponse.Unmarshal(m, b)
@@ -2445,7 +2448,7 @@ func (m *ControllerServiceCapability) Reset()         { *m = ControllerServiceCa
 func (m *ControllerServiceCapability) String() string { return proto.CompactTextString(m) }
 func (*ControllerServiceCapability) ProtoMessage()    {}
 func (*ControllerServiceCapability) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{29}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{29}
 }
 func (m *ControllerServiceCapability) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ControllerServiceCapability.Unmarshal(m, b)
@@ -2555,7 +2558,7 @@ func (m *ControllerServiceCapability_RPC) Reset()         { *m = ControllerServi
 func (m *ControllerServiceCapability_RPC) String() string { return proto.CompactTextString(m) }
 func (*ControllerServiceCapability_RPC) ProtoMessage()    {}
 func (*ControllerServiceCapability_RPC) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{29, 0}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{29, 0}
 }
 func (m *ControllerServiceCapability_RPC) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ControllerServiceCapability_RPC.Unmarshal(m, b)
@@ -2613,7 +2616,7 @@ func (m *CreateSnapshotRequest) Reset()         { *m = CreateSnapshotRequest{} }
 func (m *CreateSnapshotRequest) String() string { return proto.CompactTextString(m) }
 func (*CreateSnapshotRequest) ProtoMessage()    {}
 func (*CreateSnapshotRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{30}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{30}
 }
 func (m *CreateSnapshotRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CreateSnapshotRequest.Unmarshal(m, b)
@@ -2675,7 +2678,7 @@ func (m *CreateSnapshotResponse) Reset()         { *m = CreateSnapshotResponse{}
 func (m *CreateSnapshotResponse) String() string { return proto.CompactTextString(m) }
 func (*CreateSnapshotResponse) ProtoMessage()    {}
 func (*CreateSnapshotResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{31}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{31}
 }
 func (m *CreateSnapshotResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CreateSnapshotResponse.Unmarshal(m, b)
@@ -2738,7 +2741,7 @@ func (m *Snapshot) Reset()         { *m = Snapshot{} }
 func (m *Snapshot) String() string { return proto.CompactTextString(m) }
 func (*Snapshot) ProtoMessage()    {}
 func (*Snapshot) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{32}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{32}
 }
 func (m *Snapshot) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Snapshot.Unmarshal(m, b)
@@ -2809,7 +2812,7 @@ func (m *SnapshotStatus) Reset()         { *m = SnapshotStatus{} }
 func (m *SnapshotStatus) String() string { return proto.CompactTextString(m) }
 func (*SnapshotStatus) ProtoMessage()    {}
 func (*SnapshotStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{33}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{33}
 }
 func (m *SnapshotStatus) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SnapshotStatus.Unmarshal(m, b)
@@ -2860,7 +2863,7 @@ func (m *DeleteSnapshotRequest) Reset()         { *m = DeleteSnapshotRequest{} }
 func (m *DeleteSnapshotRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteSnapshotRequest) ProtoMessage()    {}
 func (*DeleteSnapshotRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{34}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{34}
 }
 func (m *DeleteSnapshotRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeleteSnapshotRequest.Unmarshal(m, b)
@@ -2904,7 +2907,7 @@ func (m *DeleteSnapshotResponse) Reset()         { *m = DeleteSnapshotResponse{}
 func (m *DeleteSnapshotResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteSnapshotResponse) ProtoMessage()    {}
 func (*DeleteSnapshotResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{35}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{35}
 }
 func (m *DeleteSnapshotResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeleteSnapshotResponse.Unmarshal(m, b)
@@ -2958,7 +2961,7 @@ func (m *ListSnapshotsRequest) Reset()         { *m = ListSnapshotsRequest{} }
 func (m *ListSnapshotsRequest) String() string { return proto.CompactTextString(m) }
 func (*ListSnapshotsRequest) ProtoMessage()    {}
 func (*ListSnapshotsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{36}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{36}
 }
 func (m *ListSnapshotsRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListSnapshotsRequest.Unmarshal(m, b)
@@ -3024,7 +3027,7 @@ func (m *ListSnapshotsResponse) Reset()         { *m = ListSnapshotsResponse{} }
 func (m *ListSnapshotsResponse) String() string { return proto.CompactTextString(m) }
 func (*ListSnapshotsResponse) ProtoMessage()    {}
 func (*ListSnapshotsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{37}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{37}
 }
 func (m *ListSnapshotsResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListSnapshotsResponse.Unmarshal(m, b)
@@ -3069,7 +3072,7 @@ func (m *ListSnapshotsResponse_Entry) Reset()         { *m = ListSnapshotsRespon
 func (m *ListSnapshotsResponse_Entry) String() string { return proto.CompactTextString(m) }
 func (*ListSnapshotsResponse_Entry) ProtoMessage()    {}
 func (*ListSnapshotsResponse_Entry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{37, 0}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{37, 0}
 }
 func (m *ListSnapshotsResponse_Entry) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListSnapshotsResponse_Entry.Unmarshal(m, b)
@@ -3131,7 +3134,7 @@ func (m *NodeStageVolumeRequest) Reset()         { *m = NodeStageVolumeRequest{}
 func (m *NodeStageVolumeRequest) String() string { return proto.CompactTextString(m) }
 func (*NodeStageVolumeRequest) ProtoMessage()    {}
 func (*NodeStageVolumeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{38}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{38}
 }
 func (m *NodeStageVolumeRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NodeStageVolumeRequest.Unmarshal(m, b)
@@ -3203,7 +3206,7 @@ func (m *NodeStageVolumeResponse) Reset()         { *m = NodeStageVolumeResponse
 func (m *NodeStageVolumeResponse) String() string { return proto.CompactTextString(m) }
 func (*NodeStageVolumeResponse) ProtoMessage()    {}
 func (*NodeStageVolumeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{39}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{39}
 }
 func (m *NodeStageVolumeResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NodeStageVolumeResponse.Unmarshal(m, b)
@@ -3239,7 +3242,7 @@ func (m *NodeUnstageVolumeRequest) Reset()         { *m = NodeUnstageVolumeReque
 func (m *NodeUnstageVolumeRequest) String() string { return proto.CompactTextString(m) }
 func (*NodeUnstageVolumeRequest) ProtoMessage()    {}
 func (*NodeUnstageVolumeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{40}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{40}
 }
 func (m *NodeUnstageVolumeRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NodeUnstageVolumeRequest.Unmarshal(m, b)
@@ -3283,7 +3286,7 @@ func (m *NodeUnstageVolumeResponse) Reset()         { *m = NodeUnstageVolumeResp
 func (m *NodeUnstageVolumeResponse) String() string { return proto.CompactTextString(m) }
 func (*NodeUnstageVolumeResponse) ProtoMessage()    {}
 func (*NodeUnstageVolumeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{41}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{41}
 }
 func (m *NodeUnstageVolumeResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NodeUnstageVolumeResponse.Unmarshal(m, b)
@@ -3349,7 +3352,7 @@ func (m *NodePublishVolumeRequest) Reset()         { *m = NodePublishVolumeReque
 func (m *NodePublishVolumeRequest) String() string { return proto.CompactTextString(m) }
 func (*NodePublishVolumeRequest) ProtoMessage()    {}
 func (*NodePublishVolumeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{42}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{42}
 }
 func (m *NodePublishVolumeRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NodePublishVolumeRequest.Unmarshal(m, b)
@@ -3435,7 +3438,7 @@ func (m *NodePublishVolumeResponse) Reset()         { *m = NodePublishVolumeResp
 func (m *NodePublishVolumeResponse) String() string { return proto.CompactTextString(m) }
 func (*NodePublishVolumeResponse) ProtoMessage()    {}
 func (*NodePublishVolumeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{43}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{43}
 }
 func (m *NodePublishVolumeResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NodePublishVolumeResponse.Unmarshal(m, b)
@@ -3471,7 +3474,7 @@ func (m *NodeUnpublishVolumeRequest) Reset()         { *m = NodeUnpublishVolumeR
 func (m *NodeUnpublishVolumeRequest) String() string { return proto.CompactTextString(m) }
 func (*NodeUnpublishVolumeRequest) ProtoMessage()    {}
 func (*NodeUnpublishVolumeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{44}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{44}
 }
 func (m *NodeUnpublishVolumeRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NodeUnpublishVolumeRequest.Unmarshal(m, b)
@@ -3515,7 +3518,7 @@ func (m *NodeUnpublishVolumeResponse) Reset()         { *m = NodeUnpublishVolume
 func (m *NodeUnpublishVolumeResponse) String() string { return proto.CompactTextString(m) }
 func (*NodeUnpublishVolumeResponse) ProtoMessage()    {}
 func (*NodeUnpublishVolumeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{45}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{45}
 }
 func (m *NodeUnpublishVolumeResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NodeUnpublishVolumeResponse.Unmarshal(m, b)
@@ -3553,7 +3556,7 @@ func (m *NodeGetVolumeStatsRequest) Reset()         { *m = NodeGetVolumeStatsReq
 func (m *NodeGetVolumeStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*NodeGetVolumeStatsRequest) ProtoMessage()    {}
 func (*NodeGetVolumeStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{46}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{46}
 }
 func (m *NodeGetVolumeStatsRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NodeGetVolumeStatsRequest.Unmarshal(m, b)
@@ -3599,7 +3602,7 @@ func (m *NodeGetVolumeStatsResponse) Reset()         { *m = NodeGetVolumeStatsRe
 func (m *NodeGetVolumeStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*NodeGetVolumeStatsResponse) ProtoMessage()    {}
 func (*NodeGetVolumeStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{47}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{47}
 }
 func (m *NodeGetVolumeStatsResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NodeGetVolumeStatsResponse.Unmarshal(m, b)
@@ -3647,7 +3650,7 @@ func (m *VolumeUsage) Reset()         { *m = VolumeUsage{} }
 func (m *VolumeUsage) String() string { return proto.CompactTextString(m) }
 func (*VolumeUsage) ProtoMessage()    {}
 func (*VolumeUsage) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{48}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{48}
 }
 func (m *VolumeUsage) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VolumeUsage.Unmarshal(m, b)
@@ -3705,7 +3708,7 @@ func (m *NodeGetIdRequest) Reset()         { *m = NodeGetIdRequest{} }
 func (m *NodeGetIdRequest) String() string { return proto.CompactTextString(m) }
 func (*NodeGetIdRequest) ProtoMessage()    {}
 func (*NodeGetIdRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{49}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{49}
 }
 func (m *NodeGetIdRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NodeGetIdRequest.Unmarshal(m, b)
@@ -3739,7 +3742,7 @@ func (m *NodeGetIdResponse) Reset()         { *m = NodeGetIdResponse{} }
 func (m *NodeGetIdResponse) String() string { return proto.CompactTextString(m) }
 func (*NodeGetIdResponse) ProtoMessage()    {}
 func (*NodeGetIdResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{50}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{50}
 }
 func (m *NodeGetIdResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NodeGetIdResponse.Unmarshal(m, b)
@@ -3776,7 +3779,7 @@ func (m *NodeGetCapabilitiesRequest) Reset()         { *m = NodeGetCapabilitiesR
 func (m *NodeGetCapabilitiesRequest) String() string { return proto.CompactTextString(m) }
 func (*NodeGetCapabilitiesRequest) ProtoMessage()    {}
 func (*NodeGetCapabilitiesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{51}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{51}
 }
 func (m *NodeGetCapabilitiesRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NodeGetCapabilitiesRequest.Unmarshal(m, b)
@@ -3809,7 +3812,7 @@ func (m *NodeGetCapabilitiesResponse) Reset()         { *m = NodeGetCapabilities
 func (m *NodeGetCapabilitiesResponse) String() string { return proto.CompactTextString(m) }
 func (*NodeGetCapabilitiesResponse) ProtoMessage()    {}
 func (*NodeGetCapabilitiesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{52}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{52}
 }
 func (m *NodeGetCapabilitiesResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NodeGetCapabilitiesResponse.Unmarshal(m, b)
@@ -3850,7 +3853,7 @@ func (m *NodeServiceCapability) Reset()         { *m = NodeServiceCapability{} }
 func (m *NodeServiceCapability) String() string { return proto.CompactTextString(m) }
 func (*NodeServiceCapability) ProtoMessage()    {}
 func (*NodeServiceCapability) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{53}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{53}
 }
 func (m *NodeServiceCapability) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NodeServiceCapability.Unmarshal(m, b)
@@ -3960,7 +3963,7 @@ func (m *NodeServiceCapability_RPC) Reset()         { *m = NodeServiceCapability
 func (m *NodeServiceCapability_RPC) String() string { return proto.CompactTextString(m) }
 func (*NodeServiceCapability_RPC) ProtoMessage()    {}
 func (*NodeServiceCapability_RPC) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{53, 0}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{53, 0}
 }
 func (m *NodeServiceCapability_RPC) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NodeServiceCapability_RPC.Unmarshal(m, b)
@@ -3997,7 +4000,7 @@ func (m *NodeGetInfoRequest) Reset()         { *m = NodeGetInfoRequest{} }
 func (m *NodeGetInfoRequest) String() string { return proto.CompactTextString(m) }
 func (*NodeGetInfoRequest) ProtoMessage()    {}
 func (*NodeGetInfoRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{54}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{54}
 }
 func (m *NodeGetInfoRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NodeGetInfoRequest.Unmarshal(m, b)
@@ -4055,7 +4058,7 @@ func (m *NodeGetInfoResponse) Reset()         { *m = NodeGetInfoResponse{} }
 func (m *NodeGetInfoResponse) String() string { return proto.CompactTextString(m) }
 func (*NodeGetInfoResponse) ProtoMessage()    {}
 func (*NodeGetInfoResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_csi_d2a705310653d01b, []int{55}
+	return fileDescriptor_csi_68cc61910dffa6c4, []int{55}
 }
 func (m *NodeGetInfoResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NodeGetInfoResponse.Unmarshal(m, b)
@@ -5032,10 +5035,10 @@ var _Node_serviceDesc = grpc.ServiceDesc{
 }
 
 func init() {
-	proto.RegisterFile("github.com/container-storage-interface/spec/csi.proto", fileDescriptor_csi_d2a705310653d01b)
+	proto.RegisterFile("github.com/container-storage-interface/spec/csi.proto", fileDescriptor_csi_68cc61910dffa6c4)
 }
 
-var fileDescriptor_csi_d2a705310653d01b = []byte{
+var fileDescriptor_csi_68cc61910dffa6c4 = []byte{
 	// 3125 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xcc, 0x3a, 0x4d, 0x6f, 0x23, 0xc7,
 	0xb1, 0x1a, 0x7e, 0xe8, 0xa3, 0xb4, 0x92, 0xb9, 0xad, 0x2f, 0x6a, 0x24, 0xed, 0x6a, 0x67, 0xbd,

--- a/spec.md
+++ b/spec.md
@@ -471,13 +471,13 @@ message GetPluginInfoRequest {
 }
 
 message GetPluginInfoResponse {
-  // The name MUST follow reverse domain name notation format
-  // (https://en.wikipedia.org/wiki/Reverse_domain_name_notation).
-  // It SHOULD include the plugin's host company name and the plugin
-  // name, to minimize the possibility of collisions. It MUST be 63
+  // The name MUST follow domain name notation format
+  // (https://tools.ietf.org/html/rfc1035#section-2.3.1). It SHOULD
+  // include the plugin's host company name and the plugin name,
+  // to minimize the possibility of collisions. It MUST be 63
   // characters or less, beginning and ending with an alphanumeric
-  // character ([a-z0-9A-Z]) with dashes (-), underscores (_),
-  // dots (.), and alphanumerics between. This field is REQUIRED.
+  // character ([a-z0-9A-Z]) with dashes (-), dots (.), and
+  // alphanumerics between. This field is REQUIRED.
   string name = 1;
 
   // This field is REQUIRED. Value of this field is opaque to the CO.
@@ -975,12 +975,15 @@ message TopologyRequirement {
 // Valid keys have two segments: an optional prefix and name, separated
 // by a slash (/), for example: "com.company.example/zone".
 // The key name segment is required. The prefix is optional.
-// Both the key name and the prefix MUST each be 63 characters or less,
-// begin and end with an alphanumeric character ([a-z0-9A-Z]) and
-// contain only dashes (-), underscores (_), dots (.), or alphanumerics
-// in between, for example "zone".
-// The key prefix MUST follow reverse domain name notation format
-// (https://en.wikipedia.org/wiki/Reverse_domain_name_notation).
+// The key name MUST be 63 characters or less, begin and end with an
+// alphanumeric character ([a-z0-9A-Z]), and contain only dashes (-),
+// underscores (_), dots (.), or alphanumerics in between, for example
+// "zone".
+// The key prefix MUST be 63 characters or less, begin and end with a
+// lower-case alphanumeric character ([a-z0-9]), contain only
+// dashes (-), dots (.), or lower-case alphanumerics in between, and
+// follow domain name notation format
+// (https://tools.ietf.org/html/rfc1035#section-2.3.1).
 // The key prefix SHOULD include the plugin's host company name and/or
 // the plugin name, to minimize the possibility of collisions with keys
 // from other plugins.


### PR DESCRIPTION
This PR makes explicit the implicit restriction that underscores "_" are not allowed in the prefix format, as described in the wiki link. It also proposes to further restrict prefixes to lower-case letters only. Internally in k8s, topology is represented by labels, which unfortunately doesn't allow either underscores or capitalized letters.

This should be a fairly low-risk change, but definitely still worth broadcasting in the next spec release.