### PR TITLE
spec: ListVolumes, ListSnapshots consistency.

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1225,6 +1225,8 @@ The CO MUST implement the specified error recovery behavior when it encounters t
 
 A Controller Plugin MUST implement this RPC call if it has `LIST_VOLUMES` capability.
 The Plugin SHALL return the information about all the volumes that it knows about.
+If volumes are created and/or deleted while the CO is concurrently paging through `ListVolumes` results then it is possible that the CO MAY either witness duplicate volumes in the list, not witness existing volumes, or both.
+The CO SHALL NOT expect a consistent "view" of all volumes when paging through the volume list via multiple calls to `ListVolumes`.
 
 ```protobuf
 message ListVolumesRequest {
@@ -1538,6 +1540,8 @@ The CO MUST implement the specified error recovery behavior when it encounters t
 A Controller Plugin MUST implement this RPC call if it has `LIST_SNAPSHOTS` capability.
 The Plugin SHALL return the information about all snapshots on the storage system within the given parameters regardless of how they were created.
 `ListSnapshots` SHALL NOT list a snapshot that is being created but has not been cut successfully yet.
+If snapshots are created and/or deleted while the CO is concurrently paging through `ListSnapshots` results then it is possible that the CO MAY either witness duplicate snapshots in the list, not witness existing snapshots, or both.
+The CO SHALL NOT expect a consistent "view" of all snapshots when paging through the snapshot list via multiple calls to `ListSnapshots`.
 
 ```protobuf
 // List all snapshots on the storage system regardless of how they were


### PR DESCRIPTION
ListVolumes and ListSnapshots are not guaranteed to provide the CO with
a consistent, stable view across paged object lists. This change set
clarifies this expectation for COs.

Fixes #48