### PR TITLE
Add build Dockerfile with go and protoc bins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.12.7 
+
+RUN apt-get update && apt-get install -y \
+  unzip \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV PROTOC_VER "3.9.1"
+ENV PROTOC_ZIP "protoc-${PROTOC_VER}-linux-x86_64.zip"
+RUN curl -OL "https://github.com/google/protobuf/releases/download/v${PROTOC_VER}/${PROTOC_ZIP}" \
+  && unzip -o "${PROTOC_ZIP}" -d /usr/local bin/protoc \
+  && unzip -o "${PROTOC_ZIP}" -d /usr/local include/* \
+  && rm "${PROTOC_ZIP}" 
+
+ENV PROTOC_GEN_GO_VERSION "v1.3.2" 
+RUN go get -d -u github.com/golang/protobuf/protoc-gen-go \
+  && git -C "$(go env GOPATH)"/src/github.com/golang/protobuf checkout "${PROTOC_GEN_GO_VERSION}" \
+  && go install github.com/golang/protobuf/protoc-gen-go
+


### PR DESCRIPTION
## Overview
Adds a Dockerfile with tools required to generate/compile the spec. In a followup, this can be pushed and consumed from the Makefile

## Issues
* https://github.com/container-storage-interface/spec/issues/377

## Test Plan
```
[10:24:37]tom@tom-XPS-13-9360: (add-dockerfile)~/tmp/repos/spec/ docker build . -t tmp
Sending build context to Docker daemon  2.161MB
Step 1/7 : FROM golang:1.12.7
 ---> be63d15101cb
Step 2/7 : RUN apt-get update && apt-get install -y   unzip   && rm -rf /var/lib/apt/lists/*
 ---> Using cache
 ---> 602853629dd1
Step 3/7 : ENV PROTOC_VER "3.9.1"
 ---> Using cache
 ---> 30f68ccd998f
Step 4/7 : ENV PROTOC_ZIP "protoc-${PROTOC_VER}-linux-x86_64.zip"
 ---> Using cache
 ---> 34b5861b8ee3
Step 5/7 : RUN curl -OL "https://github.com/google/protobuf/releases/download/v${PROTOC_VER}/${PROTOC_ZIP}"   && unzip -o "${PROTOC_ZIP}" -d /usr/local bin/protoc   && unzip -o "${PROTOC_ZIP}" -d /usr/local include/*   && rm "${PROTOC_ZIP}"
 ---> Using cache
 ---> b23541b656ae
Step 6/7 : ENV PROTOC_GEN_GO_VERSION "v1.3.2"
 ---> Using cache
 ---> d189d0ef0a0d
Step 7/7 : RUN go get -d -u github.com/golang/protobuf/protoc-gen-go   && git -C "$(go env GOPATH)"/src/github.com/golang/protobuf checkout "${PROTOC_GEN_GO_VERSION}"   && go install github.com/golang/protobuf/protoc-gen-go
 ---> Using cache
 ---> 3801f50352d0
Successfully built 3801f50352d0
Successfully tagged tmp:latest
[10:24:57]tom@tom-XPS-13-9360: (add-dockerfile)~/tmp/repos/spec/ docker run -it tmp bash
root@b43777503e04:/go# which protoc
/usr/local/bin/protoc
root@b43777503e04:/go# which protoc-gen-go
/go/bin/protoc-gen-go
```