### PR TITLE
Add missing directional arrows to graph transitions

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -166,7 +166,7 @@ capability.
 ```
    CreateVolume +------------+ DeleteVolume
  +------------->|  CREATED   +--------------+
- |              +---+----+---+              |
+ |              +---+----^---+              |
  |       Controller |    | Controller       v
 +++         Publish |    | Unpublish       +++
 |X|          Volume |    | Volume          | |
@@ -187,7 +187,7 @@ creation to destruction.
 ```
    CreateVolume +------------+ DeleteVolume
  +------------->|  CREATED   +--------------+
- |              +---+----+---+              |
+ |              +---+----^---+              |
  |       Controller |    | Controller       v
 +++         Publish |    | Unpublish       +++
 |X|          Volume |    | Volume          | |
@@ -199,7 +199,7 @@ creation to destruction.
              Volume |    | Volume
                 +---v----+---+
                 |  VOL_READY |
-                +------------+
+                +---+----^---+
                Node |    | Node
             Publish |    | Unpublish
              Volume |    | Volume


### PR DESCRIPTION
Just a small change to keep the life-cycle graphs consistent with the other arrows