### PR TITLE
Add a note about CSI go language bindings should be built in GOPATH

### DIFF
--- a/lib/go/README.md
+++ b/lib/go/README.md
@@ -1,6 +1,7 @@
 # CSI Go Validation
 
 This package is used to validate the CSI specification with Go language bindings.
+It is recommended to build this package inside `GOPATH`.
 
 ## Build Reference
 


### PR DESCRIPTION
Bad things happen if you try to build it outside GOPATH.