### PR TITLE
Change size limitation for all file paths and node_id

### DIFF
--- a/csi.proto
+++ b/csi.proto
@@ -1206,6 +1206,10 @@ message NodeStageVolumeRequest {
   // CO SHALL be responsible for creating the directory if it does not
   // exist.
   // This is a REQUIRED field.
+  // This field overrides the general CSI size limit.
+  // SP SHOULD support the maximum path length allowed by the operating
+  // system/filesystem, but, at a minimum, SP MUST accept a max path
+  // length of at least 128 bytes.
   string staging_target_path = 3;
 
   // Volume capability describing how the CO intends to use this volume.
@@ -1236,6 +1240,10 @@ message NodeUnstageVolumeRequest {
   // The path at which the volume was staged. It MUST be an absolute
   // path in the root filesystem of the process serving this request.
   // This is a REQUIRED field.
+  // This field overrides the general CSI size limit.
+  // SP SHOULD support the maximum path length allowed by the operating
+  // system/filesystem, but, at a minimum, SP MUST accept a max path
+  // length of at least 128 bytes.
   string staging_target_path = 2;
 }
 
@@ -1259,6 +1267,10 @@ message NodePublishVolumeRequest {
   // It MUST be set if the Node Plugin implements the
   // `STAGE_UNSTAGE_VOLUME` node capability.
   // This is an OPTIONAL field.
+  // This field overrides the general CSI size limit.
+  // SP SHOULD support the maximum path length allowed by the operating
+  // system/filesystem, but, at a minimum, SP MUST accept a max path
+  // length of at least 128 bytes.
   string staging_target_path = 3;
 
   // The path to which the volume will be published. It MUST be an
@@ -1273,6 +1285,10 @@ message NodePublishVolumeRequest {
   // mounted directory at target_path.
   // Creation of target_path is the responsibility of the SP.
   // This is a REQUIRED field.
+  // This field overrides the general CSI size limit.
+  // SP SHOULD support the maximum path length allowed by the operating
+  // system/filesystem, but, at a minimum, SP MUST accept a max path
+  // length of at least 128 bytes.
   string target_path = 4;
 
   // Volume capability describing how the CO intends to use this volume.
@@ -1308,6 +1324,10 @@ message NodeUnpublishVolumeRequest {
   // path in the root filesystem of the process serving this request.
   // The SP MUST delete the file or directory it created at this path.
   // This is a REQUIRED field.
+  // This field overrides the general CSI size limit.
+  // SP SHOULD support the maximum path length allowed by the operating
+  // system/filesystem, but, at a minimum, SP MUST accept a max path
+  // length of at least 128 bytes.
   string target_path = 2;
 }
 
@@ -1323,6 +1343,10 @@ message NodeGetVolumeStatsRequest {
   // It MUST be an absolute path in the root filesystem of
   // the process serving this request.
   // This is a REQUIRED field.
+  // This field overrides the general CSI size limit.
+  // SP SHOULD support the maximum path length allowed by the operating
+  // system/filesystem, but, at a minimum, SP MUST accept a max path
+  // length of at least 128 bytes.
   string volume_path = 2;
 
   // The path where the volume is staged, if the plugin has the
@@ -1330,6 +1354,10 @@ message NodeGetVolumeStatsRequest {
   // If not empty, it MUST be an absolute path in the root
   // filesystem of the process serving this request.
   // This field is OPTIONAL.
+  // This field overrides the general CSI size limit.
+  // SP SHOULD support the maximum path length allowed by the operating
+  // system/filesystem, but, at a minimum, SP MUST accept a max path
+  // length of at least 128 bytes.
   string staging_target_path = 3;
 }
 
@@ -1434,6 +1462,10 @@ message NodeGetInfoResponse {
   // `ControllerPublishVolume`, to refer to this node.
   // The SP is NOT responsible for global uniqueness of node_id across
   // multiple SPs.
+  // This field overrides the general CSI size limit.
+  // The size of this field SHALL NOT exceed 192 bytes. The general
+  // CSI size limit, 128 byte, is RECOMMENDED for best backwards
+  // compatibility.
   string node_id = 1;
 
   // Maximum number of volumes that controller can publish to the node.
@@ -1467,6 +1499,10 @@ message NodeExpandVolumeRequest {
   string volume_id = 1;
 
   // The path on which volume is available. This field is REQUIRED.
+  // This field overrides the general CSI size limit.
+  // SP SHOULD support the maximum path length allowed by the operating
+  // system/filesystem, but, at a minimum, SP MUST accept a max path
+  // length of at least 128 bytes.
   string volume_path = 2;
 
   // This allows CO to specify the capacity requirements of the volume
@@ -1482,6 +1518,10 @@ message NodeExpandVolumeRequest {
   // If not empty, it MUST be an absolute path in the root
   // filesystem of the process serving this request.
   // This field is OPTIONAL.
+  // This field overrides the general CSI size limit.
+  // SP SHOULD support the maximum path length allowed by the operating
+  // system/filesystem, but, at a minimum, SP MUST accept a max path
+  // length of at least 128 bytes.
   string staging_target_path = 4;
 
   // Volume capability describing how the CO intends to use this volume.

--- a/lib/go/csi/csi.pb.go
+++ b/lib/go/csi/csi.pb.go
@@ -3600,6 +3600,10 @@ type NodeStageVolumeRequest struct {
 	// CO SHALL be responsible for creating the directory if it does not
 	// exist.
 	// This is a REQUIRED field.
+	// This field overrides the general CSI size limit.
+	// SP SHOULD support the maximum path length allowed by the operating
+	// system/filesystem, but, at a minimum, SP MUST accept a max path
+	// length of at least 128 bytes.
 	StagingTargetPath string `protobuf:"bytes,3,opt,name=staging_target_path,json=stagingTargetPath,proto3" json:"staging_target_path,omitempty"`
 	// Volume capability describing how the CO intends to use this volume.
 	// SP MUST ensure the CO can use the staged volume as described.
@@ -3724,6 +3728,10 @@ type NodeUnstageVolumeRequest struct {
 	// The path at which the volume was staged. It MUST be an absolute
 	// path in the root filesystem of the process serving this request.
 	// This is a REQUIRED field.
+	// This field overrides the general CSI size limit.
+	// SP SHOULD support the maximum path length allowed by the operating
+	// system/filesystem, but, at a minimum, SP MUST accept a max path
+	// length of at least 128 bytes.
 	StagingTargetPath    string   `protobuf:"bytes,2,opt,name=staging_target_path,json=stagingTargetPath,proto3" json:"staging_target_path,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -3815,6 +3823,10 @@ type NodePublishVolumeRequest struct {
 	// It MUST be set if the Node Plugin implements the
 	// `STAGE_UNSTAGE_VOLUME` node capability.
 	// This is an OPTIONAL field.
+	// This field overrides the general CSI size limit.
+	// SP SHOULD support the maximum path length allowed by the operating
+	// system/filesystem, but, at a minimum, SP MUST accept a max path
+	// length of at least 128 bytes.
 	StagingTargetPath string `protobuf:"bytes,3,opt,name=staging_target_path,json=stagingTargetPath,proto3" json:"staging_target_path,omitempty"`
 	// The path to which the volume will be published. It MUST be an
 	// absolute path in the root filesystem of the process serving this
@@ -3828,6 +3840,10 @@ type NodePublishVolumeRequest struct {
 	// mounted directory at target_path.
 	// Creation of target_path is the responsibility of the SP.
 	// This is a REQUIRED field.
+	// This field overrides the general CSI size limit.
+	// SP SHOULD support the maximum path length allowed by the operating
+	// system/filesystem, but, at a minimum, SP MUST accept a max path
+	// length of at least 128 bytes.
 	TargetPath string `protobuf:"bytes,4,opt,name=target_path,json=targetPath,proto3" json:"target_path,omitempty"`
 	// Volume capability describing how the CO intends to use this volume.
 	// SP MUST ensure the CO can use the published volume as described.
@@ -3970,6 +3986,10 @@ type NodeUnpublishVolumeRequest struct {
 	// path in the root filesystem of the process serving this request.
 	// The SP MUST delete the file or directory it created at this path.
 	// This is a REQUIRED field.
+	// This field overrides the general CSI size limit.
+	// SP SHOULD support the maximum path length allowed by the operating
+	// system/filesystem, but, at a minimum, SP MUST accept a max path
+	// length of at least 128 bytes.
 	TargetPath           string   `protobuf:"bytes,2,opt,name=target_path,json=targetPath,proto3" json:"target_path,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -4054,12 +4074,20 @@ type NodeGetVolumeStatsRequest struct {
 	// It MUST be an absolute path in the root filesystem of
 	// the process serving this request.
 	// This is a REQUIRED field.
+	// This field overrides the general CSI size limit.
+	// SP SHOULD support the maximum path length allowed by the operating
+	// system/filesystem, but, at a minimum, SP MUST accept a max path
+	// length of at least 128 bytes.
 	VolumePath string `protobuf:"bytes,2,opt,name=volume_path,json=volumePath,proto3" json:"volume_path,omitempty"`
 	// The path where the volume is staged, if the plugin has the
 	// STAGE_UNSTAGE_VOLUME capability, otherwise empty.
 	// If not empty, it MUST be an absolute path in the root
 	// filesystem of the process serving this request.
 	// This field is OPTIONAL.
+	// This field overrides the general CSI size limit.
+	// SP SHOULD support the maximum path length allowed by the operating
+	// system/filesystem, but, at a minimum, SP MUST accept a max path
+	// length of at least 128 bytes.
 	StagingTargetPath    string   `protobuf:"bytes,3,opt,name=staging_target_path,json=stagingTargetPath,proto3" json:"staging_target_path,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -4504,6 +4532,10 @@ type NodeGetInfoResponse struct {
 	// `ControllerPublishVolume`, to refer to this node.
 	// The SP is NOT responsible for global uniqueness of node_id across
 	// multiple SPs.
+	// This field overrides the general CSI size limit.
+	// The size of this field SHALL NOT exceed 192 bytes. The general
+	// CSI size limit, 128 byte, is RECOMMENDED for best backwards
+	// compatibility.
 	NodeId string `protobuf:"bytes,1,opt,name=node_id,json=nodeId,proto3" json:"node_id,omitempty"`
 	// Maximum number of volumes that controller can publish to the node.
 	// If value is not set or zero CO SHALL decide how many volumes of
@@ -4584,6 +4616,10 @@ type NodeExpandVolumeRequest struct {
 	// The ID of the volume. This field is REQUIRED.
 	VolumeId string `protobuf:"bytes,1,opt,name=volume_id,json=volumeId,proto3" json:"volume_id,omitempty"`
 	// The path on which volume is available. This field is REQUIRED.
+	// This field overrides the general CSI size limit.
+	// SP SHOULD support the maximum path length allowed by the operating
+	// system/filesystem, but, at a minimum, SP MUST accept a max path
+	// length of at least 128 bytes.
 	VolumePath string `protobuf:"bytes,2,opt,name=volume_path,json=volumePath,proto3" json:"volume_path,omitempty"`
 	// This allows CO to specify the capacity requirements of the volume
 	// after expansion. If capacity_range is omitted then a plugin MAY
@@ -4597,6 +4633,10 @@ type NodeExpandVolumeRequest struct {
 	// If not empty, it MUST be an absolute path in the root
 	// filesystem of the process serving this request.
 	// This field is OPTIONAL.
+	// This field overrides the general CSI size limit.
+	// SP SHOULD support the maximum path length allowed by the operating
+	// system/filesystem, but, at a minimum, SP MUST accept a max path
+	// length of at least 128 bytes.
 	StagingTargetPath string `protobuf:"bytes,4,opt,name=staging_target_path,json=stagingTargetPath,proto3" json:"staging_target_path,omitempty"`
 	// Volume capability describing how the CO intends to use this volume.
 	// This allows SP to determine if volume is being used as a block

--- a/spec.md
+++ b/spec.md
@@ -2073,6 +2073,10 @@ message NodeStageVolumeRequest {
   // CO SHALL be responsible for creating the directory if it does not
   // exist.
   // This is a REQUIRED field.
+  // This field overrides the general CSI size limit.
+  // SP SHOULD support the maximum path length allowed by the operating
+  // system/filesystem, but, at a minimum, SP MUST accept a max path
+  // length of at least 128 bytes.
   string staging_target_path = 3;
 
   // Volume capability describing how the CO intends to use this volume.
@@ -2138,6 +2142,10 @@ message NodeUnstageVolumeRequest {
   // The path at which the volume was staged. It MUST be an absolute
   // path in the root filesystem of the process serving this request.
   // This is a REQUIRED field.
+  // This field overrides the general CSI size limit.
+  // SP SHOULD support the maximum path length allowed by the operating
+  // system/filesystem, but, at a minimum, SP MUST accept a max path
+  // length of at least 128 bytes.
   string staging_target_path = 2;
 }
 
@@ -2205,6 +2213,10 @@ message NodePublishVolumeRequest {
   // It MUST be set if the Node Plugin implements the
   // `STAGE_UNSTAGE_VOLUME` node capability.
   // This is an OPTIONAL field.
+  // This field overrides the general CSI size limit.
+  // SP SHOULD support the maximum path length allowed by the operating
+  // system/filesystem, but, at a minimum, SP MUST accept a max path
+  // length of at least 128 bytes.
   string staging_target_path = 3;
 
   // The path to which the volume will be published. It MUST be an
@@ -2219,6 +2231,10 @@ message NodePublishVolumeRequest {
   // mounted directory at target_path.
   // Creation of target_path is the responsibility of the SP.
   // This is a REQUIRED field.
+  // This field overrides the general CSI size limit.
+  // SP SHOULD support the maximum path length allowed by the operating
+  // system/filesystem, but, at a minimum, SP MUST accept a max path
+  // length of at least 128 bytes.
   string target_path = 4;
 
   // Volume capability describing how the CO intends to use this volume.
@@ -2285,6 +2301,10 @@ message NodeUnpublishVolumeRequest {
   // path in the root filesystem of the process serving this request.
   // The SP MUST delete the file or directory it created at this path.
   // This is a REQUIRED field.
+  // This field overrides the general CSI size limit.
+  // SP SHOULD support the maximum path length allowed by the operating
+  // system/filesystem, but, at a minimum, SP MUST accept a max path
+  // length of at least 128 bytes.
   string target_path = 2;
 }
 
@@ -2326,6 +2346,10 @@ message NodeGetVolumeStatsRequest {
   // It MUST be an absolute path in the root filesystem of
   // the process serving this request.
   // This is a REQUIRED field.
+  // This field overrides the general CSI size limit.
+  // SP SHOULD support the maximum path length allowed by the operating
+  // system/filesystem, but, at a minimum, SP MUST accept a max path
+  // length of at least 128 bytes.
   string volume_path = 2;
 
   // The path where the volume is staged, if the plugin has the
@@ -2333,6 +2357,10 @@ message NodeGetVolumeStatsRequest {
   // If not empty, it MUST be an absolute path in the root
   // filesystem of the process serving this request.
   // This field is OPTIONAL.
+  // This field overrides the general CSI size limit.
+  // SP SHOULD support the maximum path length allowed by the operating
+  // system/filesystem, but, at a minimum, SP MUST accept a max path
+  // length of at least 128 bytes.
   string staging_target_path = 3;
 }
 
@@ -2472,6 +2500,10 @@ message NodeGetInfoResponse {
   // `ControllerPublishVolume`, to refer to this node.
   // The SP is NOT responsible for global uniqueness of node_id across
   // multiple SPs.
+  // This field overrides the general CSI size limit.
+  // The size of this field SHALL NOT exceed 192 bytes. The general
+  // CSI size limit, 128 byte, is RECOMMENDED for best backwards
+  // compatibility.
   string node_id = 1;
 
   // Maximum number of volumes that controller can publish to the node.
@@ -2535,6 +2567,10 @@ message NodeExpandVolumeRequest {
   string volume_id = 1;
 
   // The path on which volume is available. This field is REQUIRED.
+  // This field overrides the general CSI size limit.
+  // SP SHOULD support the maximum path length allowed by the operating
+  // system/filesystem, but, at a minimum, SP MUST accept a max path
+  // length of at least 128 bytes.
   string volume_path = 2;
 
   // This allows CO to specify the capacity requirements of the volume
@@ -2550,6 +2586,10 @@ message NodeExpandVolumeRequest {
   // If not empty, it MUST be an absolute path in the root
   // filesystem of the process serving this request.
   // This field is OPTIONAL.
+  // This field overrides the general CSI size limit.
+  // SP SHOULD support the maximum path length allowed by the operating
+  // system/filesystem, but, at a minimum, SP MUST accept a max path
+  // length of at least 128 bytes.
   string staging_target_path = 4;
 
   // Volume capability describing how the CO intends to use this volume.


### PR DESCRIPTION
Size limitation default for CSI spec is 128 bytes.
This has been brought up several times in different issues[1][2] that we should increase the limitation.

I think there are two types of length now need to increase:

1. node_id
2. file_paths including(target_path, volume_path, staging_target_path)

In this PR, suggest to increase node_id length limitation to 192 bytes.
For all other paths related field, remove the limitation of 128 and instead put a minimal support size of 128 bytes

[1] https://github.com/container-storage-interface/spec/issues/350
[2] https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/issues/581 
