### PR TITLE
Relax node_id length limit to 256

### DIFF
--- a/csi.proto
+++ b/csi.proto
@@ -1499,7 +1499,7 @@ message NodeGetInfoResponse {
   // The SP is NOT responsible for global uniqueness of node_id across
   // multiple SPs.
   // This field overrides the general CSI size limit.
-  // The size of this field SHALL NOT exceed 192 bytes. The general
+  // The size of this field SHALL NOT exceed 256 bytes. The general
   // CSI size limit, 128 byte, is RECOMMENDED for best backwards
   // compatibility.
   string node_id = 1;

--- a/lib/go/csi/csi.pb.go
+++ b/lib/go/csi/csi.pb.go
@@ -4579,7 +4579,7 @@ type NodeGetInfoResponse struct {
 	// The SP is NOT responsible for global uniqueness of node_id across
 	// multiple SPs.
 	// This field overrides the general CSI size limit.
-	// The size of this field SHALL NOT exceed 192 bytes. The general
+	// The size of this field SHALL NOT exceed 256 bytes. The general
 	// CSI size limit, 128 byte, is RECOMMENDED for best backwards
 	// compatibility.
 	NodeId string `protobuf:"bytes,1,opt,name=node_id,json=nodeId,proto3" json:"node_id,omitempty"`

--- a/spec.md
+++ b/spec.md
@@ -2540,7 +2540,7 @@ message NodeGetInfoResponse {
   // The SP is NOT responsible for global uniqueness of node_id across
   // multiple SPs.
   // This field overrides the general CSI size limit.
-  // The size of this field SHALL NOT exceed 192 bytes. The general
+  // The size of this field SHALL NOT exceed 256 bytes. The general
   // CSI size limit, 128 byte, is RECOMMENDED for best backwards
   // compatibility.
   string node_id = 1;


### PR DESCRIPTION
node_id has been relaxed to 192 in https://github.com/container-storage-interface/spec/commit/396c3332ca1216dea620f64f5f2d60686ae9a0a5. But it is still not long enough for some plugins node_id. So relax the constraint to 256 to make sure this satisfy the requirements.