### PR TITLE
Maybe add c# namespace into the spec

### DIFF
--- a/csi.proto
+++ b/csi.proto
@@ -7,6 +7,7 @@ import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 
 option go_package = "csi";
+option csharp_namespace = "csi";
 
 extend google.protobuf.EnumOptions {
   // Indicates that this enum is OPTIONAL and part of an experimental


### PR DESCRIPTION
c# users of the spec need to edit it to generate the source-code to include the csharp namespace.
If the option is not allowed to be included then please remove the comment 'DO NOT EDIT'