### PR TITLE
control groups has to be represented as cgroups and not cgroup

### DIFF
--- a/csi.proto
+++ b/csi.proto
@@ -632,7 +632,7 @@ message TopologyRequirement {
   //   {"region": "R1", "zone": "Z3"}
   // preferred =
   //   {"region": "R1", "zone": "Z3"}
-  // then the the SP SHOULD first attempt to make the provisioned volume
+  // then the SP SHOULD first attempt to make the provisioned volume
   // available from "zone" "Z3" in the "region" "R1" and fall back to
   // "zone" "Z2" in the "region" "R1" if that is not possible.
   //
@@ -646,7 +646,7 @@ message TopologyRequirement {
   // preferred =
   //   {"region": "R1", "zone": "Z4"},
   //   {"region": "R1", "zone": "Z2"}
-  // then the the SP SHOULD first attempt to make the provisioned volume
+  // then the SP SHOULD first attempt to make the provisioned volume
   // accessible from "zone" "Z4" in the "region" "R1" and fall back to
   // "zone" "Z2" in the "region" "R1" if that is not possible. If that
   // is not possible, the SP may choose between either the "zone"
@@ -665,7 +665,7 @@ message TopologyRequirement {
   // preferred =
   //   {"region": "R1", "zone": "Z5"},
   //   {"region": "R1", "zone": "Z3"}
-  // then the the SP SHOULD first attempt to make the provisioned volume
+  // then the SP SHOULD first attempt to make the provisioned volume
   // accessible from the combination of the two "zones" "Z5" and "Z3" in
   // the "region" "R1". If that's not possible, it should fall back to
   // a combination of "Z5" and other possibilities from the list of

--- a/lib/go/csi/csi.pb.go
+++ b/lib/go/csi/csi.pb.go
@@ -1671,7 +1671,7 @@ type TopologyRequirement struct {
 	//   {"region": "R1", "zone": "Z3"}
 	// preferred =
 	//   {"region": "R1", "zone": "Z3"}
-	// then the the SP SHOULD first attempt to make the provisioned volume
+	// then the SP SHOULD first attempt to make the provisioned volume
 	// available from "zone" "Z3" in the "region" "R1" and fall back to
 	// "zone" "Z2" in the "region" "R1" if that is not possible.
 	//
@@ -1685,7 +1685,7 @@ type TopologyRequirement struct {
 	// preferred =
 	//   {"region": "R1", "zone": "Z4"},
 	//   {"region": "R1", "zone": "Z2"}
-	// then the the SP SHOULD first attempt to make the provisioned volume
+	// then the SP SHOULD first attempt to make the provisioned volume
 	// accessible from "zone" "Z4" in the "region" "R1" and fall back to
 	// "zone" "Z2" in the "region" "R1" if that is not possible. If that
 	// is not possible, the SP may choose between either the "zone"
@@ -1704,7 +1704,7 @@ type TopologyRequirement struct {
 	// preferred =
 	//   {"region": "R1", "zone": "Z5"},
 	//   {"region": "R1", "zone": "Z3"}
-	// then the the SP SHOULD first attempt to make the provisioned volume
+	// then the SP SHOULD first attempt to make the provisioned volume
 	// accessible from the combination of the two "zones" "Z5" and "Z3" in
 	// the "region" "R1". If that's not possible, it should fall back to
 	// a combination of "Z5" and other possibilities from the list of

--- a/spec.md
+++ b/spec.md
@@ -1099,7 +1099,7 @@ message TopologyRequirement {
   //   {"region": "R1", "zone": "Z3"}
   // preferred =
   //   {"region": "R1", "zone": "Z3"}
-  // then the the SP SHOULD first attempt to make the provisioned volume
+  // then the SP SHOULD first attempt to make the provisioned volume
   // available from "zone" "Z3" in the "region" "R1" and fall back to
   // "zone" "Z2" in the "region" "R1" if that is not possible.
   //
@@ -1113,7 +1113,7 @@ message TopologyRequirement {
   // preferred =
   //   {"region": "R1", "zone": "Z4"},
   //   {"region": "R1", "zone": "Z2"}
-  // then the the SP SHOULD first attempt to make the provisioned volume
+  // then the SP SHOULD first attempt to make the provisioned volume
   // accessible from "zone" "Z4" in the "region" "R1" and fall back to
   // "zone" "Z2" in the "region" "R1" if that is not possible. If that
   // is not possible, the SP may choose between either the "zone"
@@ -1132,7 +1132,7 @@ message TopologyRequirement {
   // preferred =
   //   {"region": "R1", "zone": "Z5"},
   //   {"region": "R1", "zone": "Z3"}
-  // then the the SP SHOULD first attempt to make the provisioned volume
+  // then the SP SHOULD first attempt to make the provisioned volume
   // accessible from the combination of the two "zones" "Z5" and "Z3" in
   // the "region" "R1". If that's not possible, it should fall back to
   // a combination of "Z5" and other possibilities from the list of

--- a/spec.md
+++ b/spec.md
@@ -26,7 +26,7 @@ An implementation is compliant if it satisfies all the MUST, REQUIRED, and SHALL
 | CO                | Container Orchestration system, communicates with Plugins using CSI service RPCs.                                     |
 | SP                | Storage Provider, the vendor of a CSI plugin implementation.                                                          |
 | RPC               | [Remote Procedure Call](https://en.wikipedia.org/wiki/Remote_procedure_call).                                         |
-| Node              | A host where the user workload will be running, uniquely identifiable from the perspective of a Plugin by a node ID. |
+| Node              | A host where the user workload will be running, uniquely identifiable from the perspective of a Plugin by a node ID.  |
 | Plugin            | Aka “plugin implementation”, a gRPC endpoint that implements the CSI Services.                                        |
 | Plugin Supervisor | Process that governs the lifecycle of a Plugin, MAY be the CO.                                                        |
 | Workload          | The atomic unit of "work" scheduled by a CO. This MAY be a container or a collection of containers.                   |
@@ -2848,10 +2848,10 @@ Supervised plugins MAY be isolated and/or resource-bounded.
 * A Plugin SHOULD NOT assume that it is in the same [Linux namespaces](https://en.wikipedia.org/wiki/Linux_namespaces) as the Plugin Supervisor.
   The CO MUST clearly document the [mount propagation](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt) requirements for Node Plugins and the Plugin Supervisor SHALL satisfy the CO’s requirements.
 
-##### Cgroup Isolation
+##### Cgroups Isolation
 
 * A Plugin MAY be constrained by cgroups.
-* An operator or Plugin Supervisor MAY configure the devices cgroup subsystem to ensure that a Plugin MAY access requisite devices.
+* An operator or Plugin Supervisor MAY configure the devices cgroups subsystem to ensure that a Plugin MAY access requisite devices.
 * A Plugin Supervisor MAY define resource limits for a Plugin.
 
 ##### Resource Requirements


### PR DESCRIPTION
Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

- [x] s/cgorup/cgroup in spec
- [x] corrected table alignment
- [x] corrected few typos  