### PR TITLE
Remove "optional" for GetVolumeGroupSnapshot to avoid confusion

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -3086,7 +3086,7 @@ The CO MUST implement the specified error recovery behavior when it encounters t
 
 #### `GetVolumeGroupSnapshot`
 
-This optional RPC MAY be called by the CO to fetch current information about a volume group snapshot.
+This RPC MAY be called by the CO to fetch current information about a volume group snapshot.
 
 A Controller Plugin MUST implement this `GetVolumeGroupSnapshot` RPC call if it has `CREATE_DELETE_GET_VOLUME_GROUP_SNAPSHOT` capability.
 


### PR DESCRIPTION
**What type of PR is this?**
cleanup

**What this PR does / why we need it**:
This PR removes "optional" from the following description about `GetVolumeGroupSnapshot`. Technically this sentence is correct as `GetVolumeGroupSnapshot` is optional. However, it adds confusion as the sentence immediately following this says it must be implemented if a plugin has `CREATE_DELETE_GET_VOLUME_GROUP_SNAPSHOT` capability. For volume group snapshots, there is a single capability for create/delete/get volume group snapshots. If that capability is supported, all there RPCs create/delete/get must be implemented.

```
This optional RPC MAY be called by the CO to fetch current information about a volume group snapshot.

A Controller Plugin MUST implement this `GetVolumeGroupSnapshot` RPC call if it has `CREATE_DELETE_GET_VOLUME_GROUP_SNAPSHOT` capability.
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce an API-breaking change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```
