### PR TITLE
Documented FAILED_PRECONDITION as a possible error for GetMetadataDelta

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -3343,7 +3343,7 @@ The following conditions are well defined:
 
 | Condition | gRPC Code | Description | Recovery Behavior |
 |-----------|-----------|-------------|-------------------|
-| Missing or otherwise invalid argument | 3 INVALID_ARGUMENT | Indicates that a required argument field was not specified or an argument value is invalid | The caller should correct the error and resubmit the call. |
+| Missing or otherwise invalid argument | 3 INVALID_ARGUMENT | Indicates that a required argument field was not specified or an argument value is invalid. | The caller should correct the error and resubmit the call. |
 | Invalid `snapshot_id` | 5 NOT_FOUND | Indicates that the snapshot specified was not found. | The caller should re-check that this object exists. |
 | Invalid `starting_offset` | 11 OUT_OF_RANGE | The starting offset is negative or exceeds the volume size. | The caller should specify a valid offset. |
 
@@ -3437,8 +3437,9 @@ The following conditions are well defined:
 
 | Condition | gRPC Code | Description | Recovery Behavior |
 |-----------|-----------|-------------|-------------------|
-| Missing or otherwise invalid argument | 3 INVALID_ARGUMENT | Indicates that a required argument field was not specified or an argument value is invalid | The caller should correct the error and resubmit the call. |
+| Missing or otherwise invalid argument | 3 INVALID_ARGUMENT | Indicates that a required argument field was not specified or an argument value is invalid. | The caller should correct the error and resubmit the call. |
 | Invalid `base_snapshot_id` or `target_snapshot_id` | 5 NOT_FOUND | Indicates that the snapshots specified were not found. | The caller should re-check that these objects exist. |
+| Changed block tracking is not enabled | 9 FAILED_PRECONDITION | Changed block tracking has not been enabled in the underlying storage subsystem. | The caller should perform a full backup instead. The operation would proceed if changed block tracking was enabled in the storage subsystem, but how this is to be accomplished is beyond the scope of this specification. |
 | Invalid `starting_offset` | 11 OUT_OF_RANGE | The starting offset is negative or exceeds the volume size. | The caller should specify a valid offset. |
 
 ## Protocol


### PR DESCRIPTION
If changed block tracking has not been enabled in the underlying storage subsystem then GetMetadataDelta will fail.
This PR documents the gRPC error code that should be returned when this happens.

**What type of PR is this?**
This is a documentation change only.

**What this PR does / why we need it**:
This provides information to CSI driver developers on the precise error code to return for this error, and
guidance to the backup application developer on how to respond.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
This change was discussed in the Data Protection Working Group meeting.

**Does this PR introduce an API-breaking change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
